### PR TITLE
fix: docker compose errors

### DIFF
--- a/database/struct_node.sql
+++ b/database/struct_node.sql
@@ -39,7 +39,7 @@ CREATE TABLE `job_header` (
   `jobheaderid` int(11) NOT NULL AUTO_INCREMENT,
   `jobid` int(11) NOT NULL DEFAULT '0',
   `key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `value` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `value` text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`jobheaderid`),
   KEY `jobid` (`jobid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@
 version: "3.9"
 services:
   mysql-master:
-    image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password --sql_mode="" --skip-name-resolve --tls-version=""
+    image: mysql:8.4
+    command: --skip-name-resolve
     environment:
       MYSQL_ROOT_PASSWORD: ${MASTER_MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MASTER_MYSQL_DATABASE}
@@ -18,8 +18,8 @@ services:
       - ./database/struct_master.sql:/docker-entrypoint-initdb.d/00_struct_master.sql
       - ./docker-data/config/config_master.sql:/docker-entrypoint-initdb.d/01_config_master.sql
   mysql-node:
-    image: mysql:8
-    command: --default-authentication-plugin=mysql_native_password --sql_mode="" --skip-name-resolve --tls-version=""
+    image: mysql:8.4
+    command: --skip-name-resolve
     environment:
       MYSQL_ROOT_PASSWORD: ${NODE_MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${NODE_MYSQL_DATABASE}


### PR DESCRIPTION
This fixes the errors I had when running `docker compose up` I mention in #242. You can test the changes in a github codespace with 16gb ram. I also fix the mysql image to 8.4 to prevent new changes causing breaking changes.