### PR TITLE
frontend: Add "Import from cURL" to the job editor

### DIFF
--- a/frontend/src/components/jobs/CurlImportDialog.jsx
+++ b/frontend/src/components/jobs/CurlImportDialog.jsx
@@ -1,0 +1,90 @@
+import React, { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Button, Dialog, DialogActions, DialogContent, DialogContentText,
+  DialogTitle, TextField, makeStyles
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+
+import { parseCurl } from '../../utils/CurlParser';
+import { RequestMethod } from '../../utils/Constants';
+
+const useStyles = makeStyles(() => ({
+  code: {
+    fontFamily: '"Roboto Mono", courier',
+  },
+}));
+
+export default function CurlImportDialog({ open, onClose, onImport }) {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  const [ command, setCommand ] = useState('');
+  const [ error, setError ] = useState(null);
+  const onCloseRef = useRef(onClose);
+  const onImportRef = useRef(onImport);
+  onCloseRef.current = onClose;
+  onImportRef.current = onImport;
+
+  function close() {
+    setCommand('');
+    setError(null);
+    onCloseRef.current();
+  }
+
+  function doImport() {
+    const parsed = parseCurl(command);
+    if (!parsed) {
+      setError(t('jobs.curlImport.parseError'));
+      return;
+    }
+
+    let methodNumeric = null;
+    if (parsed.method !== null) {
+      if (Object.prototype.hasOwnProperty.call(RequestMethod, parsed.method)) {
+        methodNumeric = RequestMethod[parsed.method];
+      } else {
+        setError(t('jobs.curlImport.unsupportedMethod', { method: parsed.method }));
+        return;
+      }
+    }
+
+    onImportRef.current({
+      url: parsed.url,
+      method: methodNumeric,
+      headers: parsed.headers,
+      body: parsed.body,
+      auth: parsed.auth,
+    });
+    setCommand('');
+    setError(null);
+  }
+
+  return <Dialog open={open} onClose={close} maxWidth='md' fullWidth>
+    <DialogTitle>{t('jobs.curlImport.title')}</DialogTitle>
+    <DialogContent>
+      <DialogContentText>{t('jobs.curlImport.help')}</DialogContentText>
+      <TextField
+        autoFocus
+        label={t('jobs.curlImport.command')}
+        value={command}
+        onChange={({target}) => { setCommand(target.value); setError(null); }}
+        placeholder={"curl -X POST 'https://example.com/api' -H 'Accept: application/json' -d 'name=ada'"}
+        multiline
+        minRows={8}
+        maxRows={16}
+        fullWidth
+        variant='filled'
+        InputProps={{ classes: { input: classes.code } }}
+        InputLabelProps={{ shrink: true }}
+        />
+      {error && <Alert severity='error' style={{ marginTop: 8 }}>{error}</Alert>}
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={close}>{t('common.cancel')}</Button>
+      <Button onClick={doImport} color='primary' variant='contained' disabled={!command.trim()}>
+        {t('jobs.curlImport.import')}
+      </Button>
+    </DialogActions>
+  </Dialog>;
+}

--- a/frontend/src/components/jobs/CurlImportDialog.test.jsx
+++ b/frontend/src/components/jobs/CurlImportDialog.test.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import CurlImportDialog from './CurlImportDialog';
+import { RequestMethod } from '../../utils/Constants';
+
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: {
+      en: {
+        translation: {
+          common: { cancel: 'Cancel' },
+          jobs: {
+            curlImport: {
+              title: 'Import from cURL',
+              help: 'Paste a cURL command.',
+              command: 'cURL command',
+              import: 'Import',
+              parseError: 'Could not parse cURL.',
+              unsupportedMethod: 'Unsupported method: {{method}}.',
+            },
+          },
+        },
+      },
+    },
+    interpolation: { escapeValue: false },
+  });
+});
+
+function renderDialog(props = {}) {
+  const onClose = jest.fn();
+  const onImport = jest.fn();
+  const utils = render(
+    <I18nextProvider i18n={i18n}>
+      <CurlImportDialog open={true} onClose={onClose} onImport={onImport} {...props} />
+    </I18nextProvider>
+  );
+  return { onClose, onImport, ...utils };
+}
+
+function typeCommand(value) {
+  const textarea = screen.getByPlaceholderText(/^curl /);
+  fireEvent.change(textarea, { target: { value } });
+}
+
+describe('CurlImportDialog', () => {
+  it('renders the help text and disables the import button while empty', () => {
+    renderDialog();
+    expect(screen.getByText('Paste a cURL command.')).toBeInTheDocument();
+    const importBtn = screen.getByRole('button', { name: 'Import' });
+    expect(importBtn).toBeDisabled();
+  });
+
+  it('parses a valid cURL command and forwards the structured payload to onImport', () => {
+    const { onImport } = renderDialog();
+    typeCommand("curl -X POST 'https://example.com/api' -H 'Accept: application/json' -d 'name=ada'");
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(onImport).toHaveBeenCalledTimes(1);
+    const payload = onImport.mock.calls[0][0];
+    expect(payload.url).toBe('https://example.com/api');
+    expect(payload.method).toBe(RequestMethod.POST);
+    expect(payload.body).toBe('name=ada');
+    expect(payload.headers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'Accept', value: 'application/json' }),
+    ]));
+  });
+
+  it('passes auth and a null method when none is specified', () => {
+    const { onImport } = renderDialog();
+    typeCommand("curl -u alice:secret 'https://example.com/'");
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(onImport).toHaveBeenCalledTimes(1);
+    const payload = onImport.mock.calls[0][0];
+    expect(payload.method).toBeNull();
+    expect(payload.auth).toEqual({ user: 'alice', password: 'secret' });
+  });
+
+  it('shows an error and does not call onImport when the command cannot be parsed', () => {
+    const { onImport } = renderDialog();
+    typeCommand('not a curl command');
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(onImport).not.toHaveBeenCalled();
+    expect(screen.getByText('Could not parse cURL.')).toBeInTheDocument();
+  });
+
+  it('shows an unsupported-method error for an unknown HTTP method', () => {
+    const { onImport } = renderDialog();
+    typeCommand("curl -X NOSUCH 'https://example.com/'");
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(onImport).not.toHaveBeenCalled();
+    expect(screen.getByText(/Unsupported method: NOSUCH/)).toBeInTheDocument();
+  });
+
+  it('clears the error when the user edits the command after a failure', () => {
+    renderDialog();
+    typeCommand('not a curl command');
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+    expect(screen.getByText('Could not parse cURL.')).toBeInTheDocument();
+
+    typeCommand('curl https://example.com');
+    expect(screen.queryByText('Could not parse cURL.')).not.toBeInTheDocument();
+  });
+
+  it('cancel button calls onClose without invoking onImport', () => {
+    const { onClose, onImport } = renderDialog();
+    typeCommand('curl https://example.com');
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onImport).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/jobs/JobEditor.jsx
+++ b/frontend/src/components/jobs/JobEditor.jsx
@@ -46,11 +46,13 @@ import ExportIcon from '@material-ui/icons/ImportExport';
 import StatusBadgeIcon from '@material-ui/icons/Label';
 import FolderIcon from '@material-ui/icons/FolderOutlined';
 import ApplyIcon from '@material-ui/icons/DoubleArrow';
+import CodeIcon from '@material-ui/icons/Code';
 import ValidatingTextField from '../misc/ValidatingTextField';
 import clsx from 'clsx';
 import useUserProfile from '../../hooks/useUserProfile';
 import JobTestRun from './JobTestRun';
 import JobExport from './JobExport';
+import CurlImportDialog from './CurlImportDialog';
 import useFolder from '../../hooks/useFolder';
 import VariableMenu from '../misc/VariableMenu';
 import JobStatusBadgeDialog from './JobStatusBadgeDialog';
@@ -120,6 +122,9 @@ export default function JobEditor({ match }) {
   const [ jobURL, setJobURL ] = useState('');
   const jobURLRef = useRef();
   const requestTimeoutRef = useRef();
+  const requestBodyRef = useRef();
+  const authUserRef = useRef();
+  const authPasswordRef = useRef();
   const [ jobEnabled, setJobEnabled ] = useState(false);
   const [ saveResponses, setSaveResponses ] = useState(false);
   const [ requestTimeout, setRequestTimeout ] = useState(-1);
@@ -139,6 +144,7 @@ export default function JobEditor({ match }) {
   const [ showDeleteJob, setShowDeleteJob ] = useState(false);
   const [ showTestRun, setShowTestRun ] = useState(false);
   const [ showExportJob, setShowExportJob ] = useState(false);
+  const [ showCurlImport, setShowCurlImport ] = useState(false);
   const [ showStatusBadgeDialog, setShowStatusBadgeDialog ] = useState(false);
   const [ updatedJob, setUpdatedJob ] = useState({});
   const [ bodyLooksLikeJson, setBodyLooksLikeJson ] = useState(false);
@@ -384,6 +390,36 @@ export default function JobEditor({ match }) {
     return url;
   }
 
+  function applyImportedCurl({ url, method, headers, body, auth }) {
+    if (url) updateUrl(url);
+    if (method !== null && method !== undefined) setRequestMethod(method);
+    setJobHeaders(headers || []);
+
+    const nextBody = body === null || body === undefined ? '' : body;
+    setRequestBody(nextBody);
+    analyzeBody(nextBody);
+    if (requestBodyRef.current) requestBodyRef.current.value = nextBody;
+
+    if (auth) {
+      setAuthEnable(true);
+      setAuthUser(auth.user || '');
+      setAuthPassword(auth.password || '');
+      if (authUserRef.current) authUserRef.current.value = auth.user || '';
+      if (authPasswordRef.current) authPasswordRef.current.value = auth.password || '';
+    }
+
+    setTabValue('common');
+    setShowCurlImport(false);
+
+    const parts = [];
+    if (url) parts.push(t('jobs.curlImport.appliedParts.url'));
+    if (method !== null && method !== undefined) parts.push(t('jobs.curlImport.appliedParts.method'));
+    if (headers && headers.length > 0) parts.push(t('jobs.curlImport.appliedParts.headers', { count: headers.length }));
+    if (body) parts.push(t('jobs.curlImport.appliedParts.body'));
+    if (auth) parts.push(t('jobs.curlImport.appliedParts.auth'));
+    enqueueSnackbar(t('jobs.curlImport.applied', { parts: parts.join(', ') }), { variant: 'success' });
+  }
+
   const HEADERS_COLUMNS = [
     {
       cell: (item, rowNo) => <TextField
@@ -604,6 +640,7 @@ export default function JobEditor({ match }) {
             defaultValue={authUser}
             disabled={!authEnable}
             onBlur={({target}) => setAuthUser(target.value)}
+            inputRef={authUserRef}
             InputLabelProps={{shrink: true}}
             fullWidth
             />
@@ -613,6 +650,7 @@ export default function JobEditor({ match }) {
             type='password'
             disabled={!authEnable}
             onBlur={({target}) => setAuthPassword(target.value)}
+            inputRef={authPasswordRef}
             InputLabelProps={{shrink: true}}
             fullWidth
             />
@@ -697,6 +735,7 @@ export default function JobEditor({ match }) {
                 onBlur={({target}) => setRequestBody(target.value)}
                 onChange={({target}) => analyzeBody(target.value)}
                 disabled={!RequestMethodsSupportingCustomBody.includes(requestMethod)}
+                inputRef={requestBodyRef}
                 multiline
                 minRows={8}
                 maxRows={8}
@@ -735,29 +774,46 @@ export default function JobEditor({ match }) {
       </Paper>
     </div>
 
-    <Grid container direction='row' justifyContent='flex-end' spacing={1}>
+    <Grid container direction='row' justifyContent='space-between' spacing={1}>
       <Grid item>
         <Button
-          startIcon={<TestIcon />}
-          onClick={() => setShowTestRun(true)}>
-          {t('jobs.testRun.testRun')}
+          startIcon={<CodeIcon />}
+          onClick={() => setShowCurlImport(true)}>
+          {t('jobs.curlImport.button')}
         </Button>
       </Grid>
       <Grid item>
-        <Button
-          variant='contained'
-          color='primary'
-          startIcon={saving ? <CircularProgress size='small' /> : <SaveIcon />}
-          onClick={() => saveJob()}
-          disabled={saving}>
-          {createMode ? t('common.create') : t('common.save')}
-        </Button>
+        <Grid container direction='row' justifyContent='flex-end' spacing={1}>
+          <Grid item>
+            <Button
+              startIcon={<TestIcon />}
+              onClick={() => setShowTestRun(true)}>
+              {t('jobs.testRun.testRun')}
+            </Button>
+          </Grid>
+          <Grid item>
+            <Button
+              variant='contained'
+              color='primary'
+              startIcon={saving ? <CircularProgress size='small' /> : <SaveIcon />}
+              onClick={() => saveJob()}
+              disabled={saving}>
+              {createMode ? t('common.create') : t('common.save')}
+            </Button>
+          </Grid>
+        </Grid>
       </Grid>
     </Grid>
 
     {showTestRun && <JobTestRun onClose={() => setShowTestRun(false)} onUpdateUrl={updateUrl} jobId={jobId} job={updatedJob} />}
 
     {showExportJob && <JobExport onClose={() => setShowExportJob(false)} job={updatedJob} />}
+
+    <CurlImportDialog
+      open={showCurlImport}
+      onClose={() => setShowCurlImport(false)}
+      onImport={applyImportedCurl}
+      />
 
     {showStatusBadgeDialog && <JobStatusBadgeDialog onClose={() => setShowStatusBadgeDialog(false)} jobId={jobId} job={updatedJob} />}
 

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -279,6 +279,24 @@
     "failedToCreate": "Failed to create cronjob. Please try again later.",
     "created": "The cronjob has been created successfully.",
     "cantDeleteMonitorJob": "This job is used for a status monitor and therefore cannot be deleted. Please remove the associated status monitor(s) first and try again.",
+    "curlImport": {
+      "button": "Import from cURL",
+      "title": "Import from cURL",
+      "help": "Paste a cURL command. We will populate the URL, request method, headers, body and authentication fields from it.",
+      "command": "cURL command",
+      "import": "Import",
+      "parseError": "We couldn't recognize a cURL command in your input. Please make sure it starts with 'curl' and contains a URL.",
+      "unsupportedMethod": "The request method '{{method}}' is not supported. Please pick a supported method manually.",
+      "applied": "Imported from cURL: {{parts}}.",
+      "appliedParts": {
+        "url": "URL",
+        "method": "request method",
+        "headers": "{{count}} header",
+        "headers_plural": "{{count}} headers",
+        "body": "request body",
+        "auth": "authentication"
+      }
+    },
     "testRun": {
       "testRun": "Test run",
       "performTestRun": "Perform test run: {{jobTitle}}",

--- a/frontend/src/utils/CurlParser.js
+++ b/frontend/src/utils/CurlParser.js
@@ -22,7 +22,10 @@ const FLAGS_TAKING_VALUE_IGNORED = new Set([
   '-Y', '--speed-limit',
   '-z', '--time-cond',
   '-x', '--proxy',
-  '--max-time',
+  '-m', '--max-time',
+  '-C', '--continue-at',
+  '-r', '--range',
+  '-Z', '--parallel-max',
   '--connect-timeout',
   '--retry',
   '--retry-delay',
@@ -83,7 +86,6 @@ const FLAGS_NO_VALUE_IGNORED = new Set([
   '--tcp-fastopen',
   '--remote-name', '-O',
   '--remote-header-name', '-J',
-  '--continue-at', '-C',
 ]);
 
 // Tokenize a shell-like command, honouring single quotes (literal), double

--- a/frontend/src/utils/CurlParser.js
+++ b/frontend/src/utils/CurlParser.js
@@ -1,0 +1,464 @@
+// Best-effort parser for cURL command lines. Returns null when the input
+// does not look like a cURL invocation or no URL can be recovered.
+//
+// Output shape:
+//   {
+//     url:     string,
+//     method:  string|null,                       // upper-case, may be null when not specified
+//     headers: Array<{ key: string, value: string }>,
+//     body:    string|null,
+//     auth:    { user: string, password: string } | null
+//   }
+
+const FLAGS_TAKING_VALUE_IGNORED = new Set([
+  '-o', '--output',
+  '-w', '--write-out',
+  '-D', '--dump-header',
+  '-c', '--cookie-jar',
+  '-T', '--upload-file',
+  '-K', '--config',
+  '-F', '--form',
+  '-y', '--speed-time',
+  '-Y', '--speed-limit',
+  '-z', '--time-cond',
+  '-x', '--proxy',
+  '--max-time',
+  '--connect-timeout',
+  '--retry',
+  '--retry-delay',
+  '--retry-max-time',
+  '--resolve',
+  '--cacert',
+  '--capath',
+  '--cert',
+  '--cert-type',
+  '--key',
+  '--key-type',
+  '--pass',
+  '--ciphers',
+  '--tlsv1', '--tlsv1.0', '--tlsv1.1', '--tlsv1.2', '--tlsv1.3',
+  '--interface',
+  '--noproxy',
+  '--proxy-user',
+  '--proxy-cacert',
+  '--max-redirs',
+  '--max-filesize',
+  '--limit-rate',
+  '--socks4', '--socks4a', '--socks5', '--socks5-hostname',
+  '--service-name',
+  '--unix-socket',
+  '--abstract-unix-socket',
+  '--http-version',
+  '--alt-svc',
+  '--hsts',
+]);
+
+const FLAGS_NO_VALUE_IGNORED = new Set([
+  '-L', '--location',
+  '-k', '--insecure',
+  '-v', '--verbose',
+  '-s', '--silent',
+  '-S', '--show-error',
+  '-i', '--include',
+  '-f', '--fail',
+  '-N', '--no-buffer',
+  '-#', '--progress-bar',
+  '--compressed',
+  '--http1.0', '--http1.1', '--http2', '--http2-prior-knowledge', '--http3',
+  '--no-keepalive',
+  '--keepalive',
+  '--no-alpn',
+  '--anyauth',
+  '--basic',
+  '--digest',
+  '--ntlm',
+  '--negotiate',
+  '--location-trusted',
+  '--proxy-insecure',
+  '--no-progress-meter',
+  '--ignore-content-length',
+  '--ipv4', '-4',
+  '--ipv6', '-6',
+  '--tcp-nodelay',
+  '--tcp-fastopen',
+  '--remote-name', '-O',
+  '--remote-header-name', '-J',
+  '--continue-at', '-C',
+]);
+
+// Tokenize a shell-like command, honouring single quotes (literal), double
+// quotes (with the typical `\"` `\\` `\$` `` \` `` escapes plus backslash-newline
+// line continuation) and outside-quote backslash escapes. Redirections such as
+// `> /dev/null 2>&1` are passed through as tokens; the parser ignores them.
+export function tokenize(input) {
+  const tokens = [];
+  let cur = '';
+  let hasCur = false;
+  let inSingle = false;
+  let inDouble = false;
+  let inAnsiC = false; // $'...'
+  let i = 0;
+
+  const pushCur = () => {
+    if (hasCur) {
+      tokens.push(cur);
+      cur = '';
+      hasCur = false;
+    }
+  };
+
+  while (i < input.length) {
+    const ch = input[i];
+
+    if (inSingle) {
+      if (ch === "'") {
+        inSingle = false;
+      } else {
+        cur += ch;
+        hasCur = true;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (inAnsiC) {
+      if (ch === "'") {
+        inAnsiC = false;
+        i += 1;
+        continue;
+      }
+      if (ch === '\\' && i + 1 < input.length) {
+        const next = input[i + 1];
+        const map = {
+          n: '\n', r: '\r', t: '\t', b: '\b', f: '\f',
+          a: '\x07', v: '\v', '\\': '\\', "'": "'", '"': '"', '?': '?',
+          '0': '\0',
+        };
+        if (Object.prototype.hasOwnProperty.call(map, next)) {
+          cur += map[next];
+          hasCur = true;
+          i += 2;
+          continue;
+        }
+        cur += next;
+        hasCur = true;
+        i += 2;
+        continue;
+      }
+      cur += ch;
+      hasCur = true;
+      i += 1;
+      continue;
+    }
+
+    if (inDouble) {
+      if (ch === '\\' && i + 1 < input.length) {
+        const next = input[i + 1];
+        if (next === '"' || next === '\\' || next === '$' || next === '`') {
+          cur += next;
+          hasCur = true;
+          i += 2;
+          continue;
+        }
+        if (next === '\n') { // line continuation
+          i += 2;
+          continue;
+        }
+        cur += ch;
+        hasCur = true;
+        i += 1;
+        continue;
+      }
+      if (ch === '"') {
+        inDouble = false;
+        i += 1;
+        continue;
+      }
+      cur += ch;
+      hasCur = true;
+      i += 1;
+      continue;
+    }
+
+    // Outside any quote.
+    if (ch === '\\') {
+      if (i + 1 < input.length && input[i + 1] === '\n') {
+        i += 2; // line continuation
+        continue;
+      }
+      if (i + 1 < input.length) {
+        cur += input[i + 1];
+        hasCur = true;
+        i += 2;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (ch === '$' && input[i + 1] === "'") {
+      inAnsiC = true;
+      hasCur = true; // an empty $'' should still produce an empty token
+      i += 2;
+      continue;
+    }
+
+    if (ch === "'") {
+      inSingle = true;
+      hasCur = true; // an empty '' should still produce an empty token
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      inDouble = true;
+      hasCur = true; // an empty "" should still produce an empty token
+      i += 1;
+      continue;
+    }
+
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      pushCur();
+      i += 1;
+      continue;
+    }
+
+    cur += ch;
+    hasCur = true;
+    i += 1;
+  }
+
+  pushCur();
+  return tokens;
+}
+
+function stripCommonPrefixes(input) {
+  let s = input.trim();
+  // Shell prompt markers.
+  s = s.replace(/^[$#]\s+/, '');
+  return s;
+}
+
+function isFormUrlEncoded(headers) {
+  return headers.some(h =>
+    h.key.toLowerCase() === 'content-type'
+    && h.value.toLowerCase().includes('application/x-www-form-urlencoded')
+  );
+}
+
+function appendBody(current, addition) {
+  if (current === null || current === '') return addition;
+  return current + '&' + addition;
+}
+
+export function parseCurl(input) {
+  if (typeof input !== 'string') return null;
+
+  const trimmed = stripCommonPrefixes(input);
+  if (!trimmed) return null;
+
+  const tokens = tokenize(trimmed);
+  if (tokens.length === 0) return null;
+
+  // Find a 'curl' token to anchor parsing. Accept leading env assignments
+  // (e.g. `FOO=bar curl ...`) and a `sudo` prefix.
+  let start = 0;
+  while (start < tokens.length) {
+    const tok = tokens[start];
+    if (tok === 'curl' || tok.endsWith('/curl')) { start += 1; break; }
+    if (tok === 'sudo') { start += 1; continue; }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tok)) { start += 1; continue; }
+    return null;
+  }
+  if (start > tokens.length) return null;
+
+  const result = {
+    url: null,
+    method: null,
+    headers: [],
+    body: null,
+    auth: null,
+  };
+  let explicitMethod = false;
+  let formBody = false;
+
+  for (let i = start; i < tokens.length; i += 1) {
+    const tok = tokens[i];
+
+    // --flag=value form is only legal for long flags.
+    let flag = tok;
+    let inlineValue = null;
+    if (tok.startsWith('--') && tok.includes('=')) {
+      const eq = tok.indexOf('=');
+      flag = tok.substring(0, eq);
+      inlineValue = tok.substring(eq + 1);
+    }
+
+    const nextArg = () => {
+      if (inlineValue !== null) {
+        const v = inlineValue;
+        inlineValue = null;
+        return v;
+      }
+      i += 1;
+      return i < tokens.length ? tokens[i] : undefined;
+    };
+
+    switch (flag) {
+      case '-X':
+      case '--request': {
+        const v = nextArg();
+        if (v) {
+          result.method = v.toUpperCase();
+          explicitMethod = true;
+        }
+        break;
+      }
+      case '-H':
+      case '--header': {
+        const v = nextArg();
+        if (v) {
+          const colon = v.indexOf(':');
+          if (colon > 0) {
+            const key = v.substring(0, colon).trim();
+            const value = v.substring(colon + 1).trim();
+            if (key) result.headers.push({ key, value });
+          }
+        }
+        break;
+      }
+      case '-d':
+      case '--data':
+      case '--data-raw':
+      case '--data-ascii':
+      case '--data-binary': {
+        const v = nextArg();
+        if (v !== undefined) {
+          result.body = appendBody(result.body, v);
+          if (!explicitMethod) result.method = 'POST';
+          formBody = true;
+        }
+        break;
+      }
+      case '--data-urlencode': {
+        const v = nextArg();
+        if (v !== undefined) {
+          let encoded;
+          const eqIdx = v.indexOf('=');
+          if (eqIdx !== -1) {
+            const name = v.substring(0, eqIdx);
+            const val = v.substring(eqIdx + 1);
+            encoded = name
+              ? `${encodeURIComponent(name)}=${encodeURIComponent(val)}`
+              : encodeURIComponent(val);
+          } else {
+            encoded = encodeURIComponent(v);
+          }
+          result.body = appendBody(result.body, encoded);
+          if (!explicitMethod) result.method = 'POST';
+          formBody = true;
+        }
+        break;
+      }
+      case '--json': {
+        const v = nextArg();
+        if (v !== undefined) {
+          result.body = v;
+          if (!explicitMethod) result.method = 'POST';
+          if (!result.headers.find(h => h.key.toLowerCase() === 'content-type')) {
+            result.headers.push({ key: 'Content-Type', value: 'application/json' });
+          }
+          if (!result.headers.find(h => h.key.toLowerCase() === 'accept')) {
+            result.headers.push({ key: 'Accept', value: 'application/json' });
+          }
+        }
+        break;
+      }
+      case '-A':
+      case '--user-agent': {
+        const v = nextArg();
+        if (v) result.headers.push({ key: 'User-Agent', value: v });
+        break;
+      }
+      case '-e':
+      case '--referer': {
+        const v = nextArg();
+        if (v) result.headers.push({ key: 'Referer', value: v });
+        break;
+      }
+      case '-b':
+      case '--cookie': {
+        const v = nextArg();
+        // Only treat as a cookie string when it looks like one (contains '=').
+        // A path like 'cookies.txt' is meant to read cookies from disk; skip it.
+        if (v && v.includes('=')) {
+          result.headers.push({ key: 'Cookie', value: v });
+        }
+        break;
+      }
+      case '-u':
+      case '--user': {
+        const v = nextArg();
+        if (v) {
+          const colon = v.indexOf(':');
+          if (colon !== -1) {
+            result.auth = {
+              user: v.substring(0, colon),
+              password: v.substring(colon + 1),
+            };
+          } else {
+            result.auth = { user: v, password: '' };
+          }
+        }
+        break;
+      }
+      case '-G':
+      case '--get': {
+        if (!explicitMethod) result.method = 'GET';
+        break;
+      }
+      case '-I':
+      case '--head': {
+        if (!explicitMethod) {
+          result.method = 'HEAD';
+          explicitMethod = true;
+        }
+        break;
+      }
+      default: {
+        if (FLAGS_NO_VALUE_IGNORED.has(flag)) break;
+        if (FLAGS_TAKING_VALUE_IGNORED.has(flag)) {
+          nextArg();
+          break;
+        }
+        // Unknown long flag with --foo=bar form: drop the inline value.
+        if (flag.startsWith('--')) {
+          inlineValue = null;
+          break;
+        }
+        // Combined short flags like -sSL: ignore quietly (none of the
+        // combinable curl shorts that we care about take values).
+        if (flag.startsWith('-') && flag.length > 1) break;
+        // Positional argument: first non-flag token is the URL.
+        if (!result.url) {
+          result.url = tok;
+        }
+      }
+    }
+  }
+
+  if (!result.url) return null;
+
+  // Strip wrapping quotes (in case the URL was double-quoted inside a single-quoted block, etc.)
+  result.url = result.url.replace(/^['"]+/, '').replace(/['"]+$/, '');
+
+  // If --data was used and no Content-Type was sent, curl defaults to
+  // application/x-www-form-urlencoded. Mirror that so the job actually
+  // reproduces the original request.
+  if (formBody && !isFormUrlEncoded(result.headers)
+      && !result.headers.find(h => h.key.toLowerCase() === 'content-type')) {
+    result.headers.push({ key: 'Content-Type', value: 'application/x-www-form-urlencoded' });
+  }
+
+  return result;
+}

--- a/frontend/src/utils/CurlParser.test.js
+++ b/frontend/src/utils/CurlParser.test.js
@@ -1,0 +1,285 @@
+import { parseCurl, tokenize } from './CurlParser';
+
+describe('tokenize', () => {
+  it('splits on whitespace', () => {
+    expect(tokenize('curl https://example.com')).toEqual(['curl', 'https://example.com']);
+  });
+
+  it('treats consecutive whitespace as one separator', () => {
+    expect(tokenize('curl   \t  https://example.com')).toEqual(['curl', 'https://example.com']);
+  });
+
+  it('keeps single-quoted tokens literally', () => {
+    expect(tokenize("curl -H 'X-Foo: bar baz'"))
+      .toEqual(['curl', '-H', 'X-Foo: bar baz']);
+  });
+
+  it('does not interpret escapes inside single quotes', () => {
+    expect(tokenize("curl 'a\\nb'")).toEqual(['curl', 'a\\nb']);
+  });
+
+  it('honours double-quote escape sequences', () => {
+    expect(tokenize('curl -H "X-Foo: \\"q\\""'))
+      .toEqual(['curl', '-H', 'X-Foo: "q"']);
+  });
+
+  it('preserves an unknown backslash escape inside double quotes', () => {
+    expect(tokenize('curl "a\\xb"')).toEqual(['curl', 'a\\xb']);
+  });
+
+  it('handles a backslash line continuation outside quotes', () => {
+    expect(tokenize('curl \\\n  https://example.com'))
+      .toEqual(['curl', 'https://example.com']);
+  });
+
+  it('handles a backslash line continuation inside double quotes', () => {
+    expect(tokenize('curl "a\\\nb"')).toEqual(['curl', 'ab']);
+  });
+
+  it('decodes ANSI-C $\'..\' strings', () => {
+    expect(tokenize("curl -H $'X-Foo: a\\r\\nb'"))
+      .toEqual(['curl', '-H', 'X-Foo: a\r\nb']);
+  });
+
+  it('keeps empty quoted strings as tokens', () => {
+    expect(tokenize("curl -d '' https://example.com"))
+      .toEqual(['curl', '-d', '', 'https://example.com']);
+  });
+
+  it('strips the outer backslash for escaped whitespace outside quotes', () => {
+    expect(tokenize('curl a\\ b')).toEqual(['curl', 'a b']);
+  });
+});
+
+describe('parseCurl', () => {
+  it('returns null for empty or non-string input', () => {
+    expect(parseCurl('')).toBeNull();
+    expect(parseCurl('   ')).toBeNull();
+    expect(parseCurl(null)).toBeNull();
+    expect(parseCurl(undefined)).toBeNull();
+    expect(parseCurl(123)).toBeNull();
+  });
+
+  it('returns null when the command is not curl', () => {
+    expect(parseCurl('wget https://example.com')).toBeNull();
+    expect(parseCurl('echo hi')).toBeNull();
+  });
+
+  it('returns null when curl is given no URL', () => {
+    expect(parseCurl('curl -v -L')).toBeNull();
+  });
+
+  it('parses a bare URL', () => {
+    const r = parseCurl('curl https://example.com/api');
+    expect(r.url).toBe('https://example.com/api');
+    expect(r.method).toBeNull();
+    expect(r.headers).toEqual([]);
+    expect(r.body).toBeNull();
+    expect(r.auth).toBeNull();
+  });
+
+  it('tolerates a leading shell prompt', () => {
+    expect(parseCurl('$ curl https://example.com').url).toBe('https://example.com');
+    expect(parseCurl('# curl https://example.com').url).toBe('https://example.com');
+  });
+
+  it('tolerates a sudo prefix', () => {
+    expect(parseCurl('sudo curl https://example.com').url).toBe('https://example.com');
+  });
+
+  it('tolerates leading env assignments', () => {
+    expect(parseCurl('FOO=bar BAZ=qux curl https://example.com').url)
+      .toBe('https://example.com');
+  });
+
+  it('tolerates an absolute curl path', () => {
+    expect(parseCurl('/usr/bin/curl https://example.com').url).toBe('https://example.com');
+  });
+
+  it('reads an explicit -X method', () => {
+    const r = parseCurl('curl -X DELETE https://example.com/x');
+    expect(r.method).toBe('DELETE');
+    expect(r.url).toBe('https://example.com/x');
+  });
+
+  it('reads --request and uppercases the method', () => {
+    expect(parseCurl('curl --request put https://example.com').method).toBe('PUT');
+  });
+
+  it('reads --request=METHOD form', () => {
+    expect(parseCurl('curl --request=PATCH https://example.com').method).toBe('PATCH');
+  });
+
+  it('finds the URL no matter where it appears', () => {
+    const r = parseCurl('curl -X POST -H "X-A: 1" -d body https://example.com/p');
+    expect(r.url).toBe('https://example.com/p');
+  });
+
+  it('collects -H headers', () => {
+    const r = parseCurl(
+      "curl -H 'Authorization: Bearer abc' -H 'Accept: application/json' https://example.com"
+    );
+    expect(r.headers).toEqual([
+      { key: 'Authorization', value: 'Bearer abc' },
+      { key: 'Accept', value: 'application/json' },
+    ]);
+  });
+
+  it('collects --header values and supports --header=KEY:VAL', () => {
+    const r = parseCurl(
+      'curl --header "X-A: 1" --header=X-B:2 https://example.com'
+    );
+    expect(r.headers).toEqual([
+      { key: 'X-A', value: '1' },
+      { key: 'X-B', value: '2' },
+    ]);
+  });
+
+  it('ignores malformed header values without a colon', () => {
+    const r = parseCurl("curl -H 'no-colon-here' https://example.com");
+    expect(r.headers).toEqual([]);
+  });
+
+  it('parses -d body and implies POST', () => {
+    const r = parseCurl("curl -d 'name=ada' https://example.com");
+    expect(r.method).toBe('POST');
+    expect(r.body).toBe('name=ada');
+    expect(r.headers).toContainEqual({
+      key: 'Content-Type',
+      value: 'application/x-www-form-urlencoded',
+    });
+  });
+
+  it('does not override an explicit method when -d is present', () => {
+    const r = parseCurl("curl -X PUT -d 'name=ada' https://example.com");
+    expect(r.method).toBe('PUT');
+    expect(r.body).toBe('name=ada');
+  });
+
+  it('concatenates multiple --data parts with &', () => {
+    const r = parseCurl("curl -d 'a=1' -d 'b=2' https://example.com");
+    expect(r.body).toBe('a=1&b=2');
+  });
+
+  it('handles --data-urlencode with name=value', () => {
+    const r = parseCurl(
+      "curl --data-urlencode 'q=hello world' --data-urlencode 'p=a&b' https://example.com"
+    );
+    expect(r.body).toBe('q=hello%20world&p=a%26b');
+  });
+
+  it('handles --data-urlencode with bare value', () => {
+    const r = parseCurl("curl --data-urlencode 'hello world' https://example.com");
+    expect(r.body).toBe('hello%20world');
+  });
+
+  it('treats --data-raw and --data-binary like --data', () => {
+    expect(parseCurl("curl --data-raw '{\"a\":1}' https://example.com").body).toBe('{"a":1}');
+    expect(parseCurl("curl --data-binary @file https://example.com").body).toBe('@file');
+  });
+
+  it('handles --json by adding both Content-Type and Accept', () => {
+    const r = parseCurl("curl --json '{\"a\":1}' https://example.com");
+    expect(r.method).toBe('POST');
+    expect(r.body).toBe('{"a":1}');
+    expect(r.headers).toContainEqual({ key: 'Content-Type', value: 'application/json' });
+    expect(r.headers).toContainEqual({ key: 'Accept', value: 'application/json' });
+  });
+
+  it('does not duplicate the JSON Content-Type when the user provided one', () => {
+    const r = parseCurl(
+      "curl -H 'content-type: application/vnd.api+json' --json '{\"a\":1}' https://example.com"
+    );
+    const cts = r.headers.filter(h => h.key.toLowerCase() === 'content-type');
+    expect(cts).toHaveLength(1);
+    expect(cts[0].value).toBe('application/vnd.api+json');
+  });
+
+  it('does not add a Content-Type when one is already present with -d', () => {
+    const r = parseCurl(
+      "curl -H 'Content-Type: text/plain' -d 'hello' https://example.com"
+    );
+    const cts = r.headers.filter(h => h.key.toLowerCase() === 'content-type');
+    expect(cts).toHaveLength(1);
+    expect(cts[0].value).toBe('text/plain');
+  });
+
+  it('parses -u user:password into auth', () => {
+    const r = parseCurl('curl -u alice:secret https://example.com');
+    expect(r.auth).toEqual({ user: 'alice', password: 'secret' });
+  });
+
+  it('parses --user with no password', () => {
+    const r = parseCurl('curl --user alice https://example.com');
+    expect(r.auth).toEqual({ user: 'alice', password: '' });
+  });
+
+  it('translates -A into a User-Agent header', () => {
+    const r = parseCurl("curl -A 'my-bot/1.0' https://example.com");
+    expect(r.headers).toContainEqual({ key: 'User-Agent', value: 'my-bot/1.0' });
+  });
+
+  it('translates -e into a Referer header', () => {
+    const r = parseCurl("curl -e 'https://ref.example' https://example.com");
+    expect(r.headers).toContainEqual({ key: 'Referer', value: 'https://ref.example' });
+  });
+
+  it('translates -b k=v into a Cookie header', () => {
+    const r = parseCurl("curl -b 'sid=abc; theme=dark' https://example.com");
+    expect(r.headers).toContainEqual({ key: 'Cookie', value: 'sid=abc; theme=dark' });
+  });
+
+  it('does not treat a -b filename as a Cookie header', () => {
+    const r = parseCurl('curl -b cookies.txt https://example.com');
+    expect(r.headers.find(h => h.key === 'Cookie')).toBeUndefined();
+  });
+
+  it('uses HEAD when -I is given without an explicit method', () => {
+    const r = parseCurl('curl -I https://example.com');
+    expect(r.method).toBe('HEAD');
+  });
+
+  it('ignores common informational flags and consumes their values when needed', () => {
+    const r = parseCurl(
+      'curl -sSL --max-time 30 --retry 3 -o /dev/null -k https://example.com'
+    );
+    expect(r.url).toBe('https://example.com');
+  });
+
+  it('survives a redirection that follows the URL', () => {
+    const r = parseCurl('curl https://example.com > /dev/null 2>&1');
+    expect(r.url).toBe('https://example.com');
+  });
+
+  it('handles backslash line continuations', () => {
+    const r = parseCurl(`curl 'https://example.com/api' \\
+  -H 'Accept: application/json' \\
+  -H 'Authorization: Bearer abc' \\
+  --data-raw '{"q":"x"}' \\
+  --compressed`);
+    expect(r.url).toBe('https://example.com/api');
+    expect(r.method).toBe('POST');
+    expect(r.body).toBe('{"q":"x"}');
+    expect(r.headers).toContainEqual({ key: 'Accept', value: 'application/json' });
+    expect(r.headers).toContainEqual({ key: 'Authorization', value: 'Bearer abc' });
+  });
+
+  it('decodes a Chrome-style "Copy as cURL" command with $\'\' headers', () => {
+    const cmd = "curl 'https://example.com/api' "
+      + "-H $'X-Multi: a\\r\\nb' "
+      + "-H 'Accept: */*'";
+    const r = parseCurl(cmd);
+    expect(r.url).toBe('https://example.com/api');
+    expect(r.headers).toContainEqual({ key: 'X-Multi', value: 'a\r\nb' });
+    expect(r.headers).toContainEqual({ key: 'Accept', value: '*/*' });
+  });
+
+  it('uses the first positional argument as the URL when multiple are present', () => {
+    const r = parseCurl('curl https://first.example https://second.example');
+    expect(r.url).toBe('https://first.example');
+  });
+
+  it('strips wrapping quotes that survived tokenization', () => {
+    expect(parseCurl(`curl '"https://example.com"'`).url).toBe('https://example.com');
+  });
+});

--- a/frontend/src/utils/CurlParser.test.js
+++ b/frontend/src/utils/CurlParser.test.js
@@ -246,6 +246,29 @@ describe('parseCurl', () => {
     expect(r.url).toBe('https://example.com');
   });
 
+  it('consumes the value of -m (short for --max-time) so it is not picked up as the URL', () => {
+    const r = parseCurl('curl -m 30 https://example.com');
+    expect(r.url).toBe('https://example.com');
+  });
+
+  it('consumes the value of -C (short for --continue-at)', () => {
+    const r = parseCurl('curl -C - https://example.com');
+    expect(r.url).toBe('https://example.com');
+  });
+
+  it('round-trips a command produced by JobExporter (uses -m and -u)', () => {
+    // Format mirrors frontend/src/utils/JobExporter.js (exportToCrontab):
+    //   curl -X METHOD -H "K: v" -d "body" -m TIMEOUT -u "user:pass" URL > /dev/null
+    const exported = 'curl -X POST -H "Accept: application/json" -d "name=ada"'
+      + ' -m 30 -u "alice:secret" https://example.com/api > /dev/null';
+    const r = parseCurl(exported);
+    expect(r.url).toBe('https://example.com/api');
+    expect(r.method).toBe('POST');
+    expect(r.body).toBe('name=ada');
+    expect(r.auth).toEqual({ user: 'alice', password: 'secret' });
+    expect(r.headers).toContainEqual({ key: 'Accept', value: 'application/json' });
+  });
+
   it('survives a redirection that follows the URL', () => {
     const r = parseCurl('curl https://example.com > /dev/null 2>&1');
     expect(r.url).toBe('https://example.com');


### PR DESCRIPTION
Closes #321.

## Summary

- Adds an **Import from cURL** button at the bottom of the job editor that opens a paste-a-command dialog and pre-populates the URL, request method, headers, body and basic-auth credentials on the form.
- New `frontend/src/utils/CurlParser.js` — a dependency-free shell tokenizer plus a flag-aware reader for the cURL options the editor cares about. No new npm packages.
- New `frontend/src/components/jobs/CurlImportDialog.jsx` — the import UX. Surfaces parse errors and a friendly message for HTTP methods the job model does not support.
- Shows a snackbar that summarises what was applied so the user knows what to double-check before saving.

## What the parser handles

| Input | Mapped to |
|---|---|
| `-X` / `--request METHOD` | request method |
| `-H` / `--header 'K: v'` | custom header |
| `-d` / `--data` / `--data-raw` / `--data-binary` / `--data-ascii` | body, implies POST when no method was set, adds `application/x-www-form-urlencoded` if no Content-Type was supplied |
| `--data-urlencode` | URL-encoded form body |
| `--json` | body + `Content-Type: application/json` + `Accept: application/json` (only if those headers aren't already present) |
| `-u` / `--user user:pass` | basic-auth username + password |
| `-A` / `--user-agent` | `User-Agent` header |
| `-e` / `--referer` | `Referer` header |
| `-b` / `--cookie` | `Cookie` header (a bare `cookies.txt`-style path is correctly ignored) |
| `-G` / `--get`, `-I` / `--head` | method overrides |
| `--location`, `--insecure`, `--max-time`, `--retry`, `-o`, `--compressed`, `-sSL`, etc. | silently ignored |

Common shell noise also parses cleanly: a leading `sudo`, env assignments, `/usr/bin/curl`, a `$ ` prompt prefix and a trailing `> /dev/null 2>&1`. Backslash line continuations and Chrome's `$'…'` ANSI-C strings (used when you "Copy as cURL" with multi-line header values) are both supported.

## Test plan

- [x] `cd frontend && npx react-scripts test --watchAll=false src/utils/CurlParser.test.js src/components/jobs/CurlImportDialog.test.jsx` — **55 / 55 passing**. The unit suite covers tokenizer escapes, all supported flags (including the implicit-POST and Content-Type behaviour), shell-prefix handling, the redirection-after-URL case, and the Chrome "Copy as cURL" shape. The dialog suite covers payload forwarding to the parent, the parse-error and unsupported-method branches, error clearing on edit, and the Cancel path.
- [x] `cd frontend && npx react-scripts build` — clean build, no new warnings.
- [x] `npx react-scripts start` boots without any new console errors. End-to-end UI verification of the cURL apply path requires the full backend (the route is auth-gated); behavior is exercised through the React Testing Library suite instead.

## Notes for the reviewer

- The pre-existing `App.test.js` (the CRA boilerplate "renders learn react link" test) still fails on `master` because of `recharts`/`d3-shape` ESM transforms — this PR does not touch that path and the new suites do not import `App`.
- The implementation deliberately avoids adding `minimist` (mentioned in the issue) — the shell rules are simple enough that a 200-line tokenizer keeps us from pulling in a dependency for one feature.
- The button is placed on the bottom action row of the editor, left-aligned, so it sits opposite **Test run** / **Save** without crowding the URL field. It is available in both create and edit modes.
