### PR TITLE
frontend: Auto-detect curl/wget commands pasted into the URL field

### DIFF
--- a/frontend/src/components/jobs/JobEditor.jsx
+++ b/frontend/src/components/jobs/JobEditor.jsx
@@ -23,6 +23,7 @@ import {
   RequestMethod,
   RequestMethodsSupportingCustomBody
 } from '../../utils/Constants';
+import { looksLikeHttpCommand, parseHttpCommand } from '../../utils/CommandParser';
 import useTimezones from '../../hooks/useTimezones';
 import NotFound from '../misc/NotFound';
 import Breadcrumbs from '../misc/Breadcrumbs';
@@ -121,6 +122,8 @@ export default function JobEditor({ match }) {
   const [ jobTitle, setJobTitle ] = useState('');
   const [ jobURL, setJobURL ] = useState('');
   const jobURLRef = useRef();
+  const [ urlFieldKey, setUrlFieldKey ] = useState(0);
+  const [ detectedCommand, setDetectedCommand ] = useState(null);
   const requestTimeoutRef = useRef();
   const requestBodyRef = useRef();
   const authUserRef = useRef();
@@ -378,7 +381,47 @@ export default function JobEditor({ match }) {
     if (jobURLRef.current) {
       jobURLRef.current.value = url;
     }
+    // The URL field manages its own value internally (see ValidatingTextField),
+    // so bump its key to remount it and pick up the new value when we set the
+    // URL programmatically (test-run redirect, cURL/wget import, ...).
+    setUrlFieldKey(key => key + 1);
     setShowTestRun(false);
+  }
+
+  // Detect a curl/wget command pasted into the URL field and remember the parsed
+  // result so we can offer a one-click import (GitHub issue #103).
+  function detectCommandInUrl(value) {
+    if (looksLikeHttpCommand(value)) {
+      const parsed = parseHttpCommand(value);
+      setDetectedCommand(parsed && parsed.url ? parsed : null);
+    } else {
+      setDetectedCommand(null);
+    }
+  }
+
+  function importDetectedCommand() {
+    if (!detectedCommand) {
+      return;
+    }
+
+    let method = null;
+    if (detectedCommand.method !== null && detectedCommand.method !== undefined) {
+      if (Object.prototype.hasOwnProperty.call(RequestMethod, detectedCommand.method)) {
+        method = RequestMethod[detectedCommand.method];
+      } else {
+        enqueueSnackbar(t('jobs.curlImport.unsupportedMethod', { method: detectedCommand.method }), { variant: 'error' });
+        return;
+      }
+    }
+
+    applyImportedCommand({
+      url: detectedCommand.url,
+      method,
+      headers: detectedCommand.headers,
+      body: detectedCommand.body,
+      auth: detectedCommand.auth,
+    });
+    setDetectedCommand(null);
   }
 
   function urlMutator(url) {
@@ -390,7 +433,7 @@ export default function JobEditor({ match }) {
     return url;
   }
 
-  function applyImportedCurl({ url, method, headers, body, auth }) {
+  function applyImportedCommand({ url, method, headers, body, auth }) {
     if (url) updateUrl(url);
     if (method !== null && method !== undefined) setRequestMethod(method);
     setJobHeaders(headers || []);
@@ -528,11 +571,13 @@ export default function JobEditor({ match }) {
             fullWidth
             />
           <ValidatingTextField
+            key={urlFieldKey}
             label={t('jobs.url')}
             mutator={urlMutator}
             defaultValue={jobURL}
             pattern={RegexPatterns.url}
             patternErrorText={t('jobs.invalidUrl')}
+            onChange={({target}) => detectCommandInUrl(target.value)}
             onBlur={({target}) => setJobURL(target.value.trim())}
             inputRef={jobURLRef}
             InputLabelProps={{shrink: true}}
@@ -543,6 +588,24 @@ export default function JobEditor({ match }) {
             fullWidth
             required
             />
+          {detectedCommand && <Box mb={2}>
+            <Alert severity='info'>
+              <AlertTitle>{t('jobs.commandImport.title')}</AlertTitle>
+              <div>
+                {t('jobs.commandImport.text')}
+              </div>
+              <Box mt={1}>
+                <Button
+                  variant='contained'
+                  size='small'
+                  color='default'
+                  startIcon={<CodeIcon />}
+                  onClick={() => importDetectedCommand()}>
+                  {t('jobs.commandImport.import')}
+                </Button>
+              </Box>
+            </Alert>
+          </Box>}
           {folders && folders.length > 0 && <div>
             <InputLabel shrink id='folder-label'>
               {t('jobs.folder')}
@@ -812,7 +875,7 @@ export default function JobEditor({ match }) {
     <CurlImportDialog
       open={showCurlImport}
       onClose={() => setShowCurlImport(false)}
-      onImport={applyImportedCurl}
+      onImport={applyImportedCommand}
       />
 
     {showStatusBadgeDialog && <JobStatusBadgeDialog onClose={() => setShowStatusBadgeDialog(false)} jobId={jobId} job={updatedJob} />}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -297,6 +297,11 @@
         "auth": "Authentifizierung"
       }
     },
+    "commandImport": {
+      "title": "Das sieht nach einem cURL- oder wget-Befehl aus",
+      "text": "Statt ihn als URL zu verwenden, können wir daraus die URL, die Anfrage-Methode, Header, den Anfrage-Body und die Authentifizierung auslesen.",
+      "import": "Befehl importieren"
+    },
     "testRun": {
       "testRun": "Testlauf",
       "performTestRun": "Testlauf durchführen: {{jobTitle}}",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -297,6 +297,11 @@
         "auth": "authentication"
       }
     },
+    "commandImport": {
+      "title": "This looks like a cURL or wget command",
+      "text": "Instead of using it as the URL, we can read the URL, request method, headers, body and authentication from it.",
+      "import": "Import command"
+    },
     "testRun": {
       "testRun": "Test run",
       "performTestRun": "Perform test run: {{jobTitle}}",

--- a/frontend/src/utils/CommandParser.js
+++ b/frontend/src/utils/CommandParser.js
@@ -1,0 +1,256 @@
+// Detection and parsing of HTTP command lines (cURL and wget) that users
+// sometimes paste straight into the job URL field (see GitHub issue #103).
+//
+// The cURL half lives in CurlParser.js; this module adds a wget parser and a
+// small dispatcher so the rest of the app can deal with "an HTTP command line"
+// without caring which tool produced it. Both parsers share the shell tokenizer
+// from CurlParser and return the same shape:
+//
+//   {
+//     url:     string,
+//     method:  string|null,                       // upper-case, may be null
+//     headers: Array<{ key: string, value: string }>,
+//     body:    string|null,
+//     auth:    { user: string, password: string } | null
+//   }
+
+import { tokenize, parseCurl } from './CurlParser';
+
+// Cheap check used by the UI to decide whether to offer an import. Matches a
+// leading `curl`/`wget` command word, tolerating a `$ `/`# ` prompt, a `sudo`
+// prefix, leading env assignments and an absolute path. Crucially it does NOT
+// match a normal URL such as `https://curl.example.com`.
+// The path-prefix segment deliberately excludes ':' so an executable path like
+// '/usr/bin/curl' matches while a URL such as 'https://example.com/wget' (which
+// carries a '://' scheme) does not.
+const COMMAND_PREFIX = /^\s*(?:[$#]\s+)?(?:sudo\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*(?:[\w./~-]*\/)?(curl|wget)(?:\s|$)/;
+
+export function looksLikeHttpCommand(input) {
+  if (typeof input !== 'string') return false;
+  return COMMAND_PREFIX.test(input);
+}
+
+// wget flags that take a separate value we don't care about. When the flag is
+// written as `--flag=value` the value is inline and dropped automatically; the
+// short forms below are only consumed when the token is exactly the flag (e.g.
+// `-O /dev/null`) — a glued form such as `-O-` carries its own value.
+const WGET_LONG_VALUE_IGNORED = new Set([
+  '--output-document',
+  '--output-file',
+  '--append-output',
+  '--timeout',
+  '--dns-timeout',
+  '--connect-timeout',
+  '--read-timeout',
+  '--tries',
+  '--wait',
+  '--waitretry',
+  '--directory-prefix',
+  '--execute',
+  '--level',
+  '--limit-rate',
+  '--max-redirect',
+  '--quota',
+  '--base',
+  '--include-directories',
+  '--exclude-directories',
+  '--bind-address',
+  '--ca-certificate',
+  '--ca-directory',
+  '--certificate',
+  '--certificate-type',
+  '--private-key',
+  '--private-key-type',
+  '--cut-dirs',
+  '--restrict-file-names',
+  '--progress',
+  '--compression',
+  '--report-speed',
+  '--user-agent', // handled explicitly, listed here for completeness
+]);
+
+const WGET_SHORT_VALUE_IGNORED = new Set([
+  '-O', '-o', '-a', '-T', '-t', '-w', '-P', '-e', '-l', '-Q', '-B', '-I', '-X',
+]);
+
+function stripCommandPrefix(tokens, command) {
+  let start = 0;
+  while (start < tokens.length) {
+    const tok = tokens[start];
+    if (tok === command || tok.endsWith('/' + command)) { start += 1; return start; }
+    if (tok === 'sudo') { start += 1; continue; }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tok)) { start += 1; continue; }
+    return -1;
+  }
+  return -1;
+}
+
+export function parseWget(input) {
+  if (typeof input !== 'string') return null;
+
+  let trimmed = input.trim().replace(/^[$#]\s+/, '');
+  if (!trimmed) return null;
+
+  const tokens = tokenize(trimmed);
+  const start = stripCommandPrefix(tokens, 'wget');
+  if (start === -1) return null;
+
+  const result = {
+    url: null,
+    method: null,
+    headers: [],
+    body: null,
+    auth: null,
+  };
+  let explicitMethod = false;
+  let hasBody = false;
+  let authUser = null;
+  let authPassword = null;
+
+  for (let i = start; i < tokens.length; i += 1) {
+    const tok = tokens[i];
+
+    let flag = tok;
+    let inlineValue = null;
+    if (tok.startsWith('--') && tok.includes('=')) {
+      const eq = tok.indexOf('=');
+      flag = tok.substring(0, eq);
+      inlineValue = tok.substring(eq + 1);
+    }
+
+    const nextArg = () => {
+      if (inlineValue !== null) {
+        const v = inlineValue;
+        inlineValue = null;
+        return v;
+      }
+      i += 1;
+      return i < tokens.length ? tokens[i] : undefined;
+    };
+
+    switch (flag) {
+      case '--header': {
+        const v = nextArg();
+        if (v) {
+          const colon = v.indexOf(':');
+          if (colon > 0) {
+            const key = v.substring(0, colon).trim();
+            const value = v.substring(colon + 1).trim();
+            if (key) result.headers.push({ key, value });
+          }
+        }
+        break;
+      }
+      case '--method': {
+        const v = nextArg();
+        if (v) {
+          result.method = v.toUpperCase();
+          explicitMethod = true;
+        }
+        break;
+      }
+      case '--post-data':
+      case '--body-data': {
+        const v = nextArg();
+        if (v !== undefined) {
+          result.body = v;
+          hasBody = true;
+          if (!explicitMethod && flag === '--post-data') result.method = 'POST';
+        }
+        break;
+      }
+      case '--post-file':
+      case '--body-file': {
+        const v = nextArg();
+        if (v !== undefined) {
+          result.body = v;
+          hasBody = true;
+          if (!explicitMethod && flag === '--post-file') result.method = 'POST';
+        }
+        break;
+      }
+      case '-U':
+      case '--user-agent': {
+        const v = nextArg();
+        if (v) result.headers.push({ key: 'User-Agent', value: v });
+        break;
+      }
+      case '--referer': {
+        const v = nextArg();
+        if (v) result.headers.push({ key: 'Referer', value: v });
+        break;
+      }
+      case '--header-line': {
+        nextArg();
+        break;
+      }
+      case '--user':
+      case '--http-user': {
+        const v = nextArg();
+        if (v !== undefined) authUser = v;
+        break;
+      }
+      case '--password':
+      case '--http-password': {
+        const v = nextArg();
+        if (v !== undefined) authPassword = v;
+        break;
+      }
+      default: {
+        if (WGET_LONG_VALUE_IGNORED.has(flag)) {
+          nextArg();
+          break;
+        }
+        if (flag.startsWith('--')) {
+          // Unknown long flag: an inline value is dropped, a bare flag is a toggle.
+          inlineValue = null;
+          break;
+        }
+        if (tok.startsWith('-') && tok.length > 1) {
+          // Short flag. Consume a following value only when the token is exactly
+          // a known value-taking short flag (so `-O /dev/null` works, while a
+          // glued `-O-` or a toggle like `-q` consumes nothing extra).
+          if (WGET_SHORT_VALUE_IGNORED.has(tok)) {
+            nextArg();
+          }
+          break;
+        }
+        // Positional argument: first one is the URL.
+        if (!result.url) {
+          result.url = tok;
+        }
+      }
+    }
+  }
+
+  if (!result.url) return null;
+
+  result.url = result.url.replace(/^['"]+/, '').replace(/['"]+$/, '');
+
+  if (authUser !== null || authPassword !== null) {
+    result.auth = { user: authUser || '', password: authPassword || '' };
+  }
+
+  // wget sends form-encoded bodies by default; mirror curl's behaviour so the
+  // resulting job actually reproduces the request.
+  if (hasBody && !result.headers.find(h => h.key.toLowerCase() === 'content-type')) {
+    result.headers.push({ key: 'Content-Type', value: 'application/x-www-form-urlencoded' });
+  }
+
+  return result;
+}
+
+// Parse an HTTP command line, auto-detecting whether it is curl or wget.
+// Returns the unified shape or null when nothing usable could be extracted.
+export function parseHttpCommand(input) {
+  if (typeof input !== 'string') return null;
+
+  const trimmed = input.trim().replace(/^[$#]\s+/, '');
+  const match = COMMAND_PREFIX.exec(input);
+  if (!match) return null;
+
+  if (match[1] === 'wget') {
+    return parseWget(trimmed);
+  }
+  return parseCurl(trimmed);
+}

--- a/frontend/src/utils/CommandParser.test.js
+++ b/frontend/src/utils/CommandParser.test.js
@@ -1,0 +1,172 @@
+import { looksLikeHttpCommand, parseWget, parseHttpCommand } from './CommandParser';
+import { RequestMethod } from './Constants';
+
+describe('looksLikeHttpCommand', () => {
+  it('detects a curl command', () => {
+    expect(looksLikeHttpCommand('curl https://example.com')).toBe(true);
+  });
+
+  it('detects a wget command', () => {
+    expect(looksLikeHttpCommand('wget https://example.com')).toBe(true);
+  });
+
+  it('detects commands behind a prompt, sudo, env vars or a path', () => {
+    expect(looksLikeHttpCommand('$ curl https://example.com')).toBe(true);
+    expect(looksLikeHttpCommand('sudo wget https://example.com')).toBe(true);
+    expect(looksLikeHttpCommand('FOO=bar curl https://example.com')).toBe(true);
+    expect(looksLikeHttpCommand('/usr/bin/curl https://example.com')).toBe(true);
+  });
+
+  it('does not flag a normal URL that merely contains the word curl/wget', () => {
+    expect(looksLikeHttpCommand('https://curl.example.com')).toBe(false);
+    expect(looksLikeHttpCommand('https://example.com/wget')).toBe(false);
+    expect(looksLikeHttpCommand('curlywhirly://x')).toBe(false);
+  });
+
+  it('does not flag empty or non-string input', () => {
+    expect(looksLikeHttpCommand('')).toBe(false);
+    expect(looksLikeHttpCommand('   ')).toBe(false);
+    expect(looksLikeHttpCommand(null)).toBe(false);
+    expect(looksLikeHttpCommand(undefined)).toBe(false);
+    expect(looksLikeHttpCommand(42)).toBe(false);
+  });
+});
+
+describe('parseWget', () => {
+  it('returns null for non-wget input', () => {
+    expect(parseWget('curl https://example.com')).toBeNull();
+    expect(parseWget('echo hi')).toBeNull();
+    expect(parseWget('')).toBeNull();
+    expect(parseWget(null)).toBeNull();
+  });
+
+  it('returns null when no URL is present', () => {
+    expect(parseWget('wget -q -O /dev/null')).toBeNull();
+  });
+
+  it('parses a bare URL', () => {
+    const r = parseWget('wget https://example.com/api');
+    expect(r.url).toBe('https://example.com/api');
+    expect(r.method).toBeNull();
+    expect(r.headers).toEqual([]);
+    expect(r.body).toBeNull();
+    expect(r.auth).toBeNull();
+  });
+
+  it('consumes -O /dev/null (the classic monitoring form) without taking it as the URL', () => {
+    const r = parseWget('wget -q -O /dev/null https://example.com');
+    expect(r.url).toBe('https://example.com');
+  });
+
+  it('treats a glued -O- as carrying its own value', () => {
+    const r = parseWget('wget -O- https://example.com');
+    expect(r.url).toBe('https://example.com');
+  });
+
+  it('parses --header in both = and space forms', () => {
+    const r = parseWget(
+      "wget --header='Accept: application/json' --header 'X-Token: abc' https://example.com"
+    );
+    expect(r.headers).toEqual([
+      { key: 'Accept', value: 'application/json' },
+      { key: 'X-Token', value: 'abc' },
+    ]);
+  });
+
+  it('parses --post-data and infers POST + form content type', () => {
+    const r = parseWget("wget --post-data='name=ada' https://example.com");
+    expect(r.method).toBe('POST');
+    expect(r.body).toBe('name=ada');
+    expect(r.headers).toContainEqual({
+      key: 'Content-Type',
+      value: 'application/x-www-form-urlencoded',
+    });
+  });
+
+  it('respects an explicit --method over the --post-data default', () => {
+    const r = parseWget("wget --method=PUT --body-data='x=1' https://example.com");
+    expect(r.method).toBe('PUT');
+    expect(r.body).toBe('x=1');
+  });
+
+  it('uppercases the --method value', () => {
+    expect(parseWget('wget --method=delete https://example.com').method).toBe('DELETE');
+  });
+
+  it('maps --user/--password into auth', () => {
+    const r = parseWget('wget --user=alice --password=secret https://example.com');
+    expect(r.auth).toEqual({ user: 'alice', password: 'secret' });
+  });
+
+  it('maps --http-user/--http-password into auth', () => {
+    const r = parseWget('wget --http-user=bob --http-password=pw https://example.com');
+    expect(r.auth).toEqual({ user: 'bob', password: 'pw' });
+  });
+
+  it('maps -U/--user-agent to a User-Agent header', () => {
+    expect(parseWget("wget -U 'my-bot/1.0' https://example.com").headers)
+      .toContainEqual({ key: 'User-Agent', value: 'my-bot/1.0' });
+    expect(parseWget("wget --user-agent='ua/2' https://example.com").headers)
+      .toContainEqual({ key: 'User-Agent', value: 'ua/2' });
+  });
+
+  it('maps --referer to a Referer header', () => {
+    expect(parseWget("wget --referer='https://ref.example' https://example.com").headers)
+      .toContainEqual({ key: 'Referer', value: 'https://ref.example' });
+  });
+
+  it('does not add a form content type when the user already set one', () => {
+    const r = parseWget(
+      "wget --header='Content-Type: application/json' --post-data='{}' https://example.com"
+    );
+    const cts = r.headers.filter(h => h.key.toLowerCase() === 'content-type');
+    expect(cts).toHaveLength(1);
+    expect(cts[0].value).toBe('application/json');
+  });
+
+  it('ignores assorted no-value and value flags around the URL', () => {
+    const r = parseWget(
+      'wget -nv --no-check-certificate --tries=3 --timeout 30 -P /tmp https://example.com'
+    );
+    expect(r.url).toBe('https://example.com');
+  });
+
+  it('tolerates sudo and env prefixes', () => {
+    expect(parseWget('sudo wget https://example.com').url).toBe('https://example.com');
+    expect(parseWget('FOO=bar wget https://example.com').url).toBe('https://example.com');
+  });
+});
+
+describe('parseHttpCommand', () => {
+  it('returns null for input that is not a command', () => {
+    expect(parseHttpCommand('https://example.com')).toBeNull();
+    expect(parseHttpCommand('just some text')).toBeNull();
+    expect(parseHttpCommand('')).toBeNull();
+    expect(parseHttpCommand(null)).toBeNull();
+  });
+
+  it('dispatches curl commands to the curl parser', () => {
+    const r = parseHttpCommand("curl -X POST -d 'a=1' https://example.com");
+    expect(r.url).toBe('https://example.com');
+    expect(r.method).toBe('POST');
+    expect(r.body).toBe('a=1');
+  });
+
+  it('dispatches wget commands to the wget parser', () => {
+    const r = parseHttpCommand("wget --post-data='a=1' https://example.com");
+    expect(r.url).toBe('https://example.com');
+    expect(r.method).toBe('POST');
+    expect(r.body).toBe('a=1');
+  });
+
+  it('handles a prompt prefix for both tools', () => {
+    expect(parseHttpCommand('$ curl https://example.com').url).toBe('https://example.com');
+    expect(parseHttpCommand('$ wget https://example.com').url).toBe('https://example.com');
+  });
+
+  it('returns methods as strings that map onto RequestMethod', () => {
+    const r = parseHttpCommand('wget --method=PATCH https://example.com');
+    expect(Object.prototype.hasOwnProperty.call(RequestMethod, r.method)).toBe(true);
+    expect(RequestMethod[r.method]).toBe(RequestMethod.PATCH);
+  });
+});


### PR DESCRIPTION
Closes #103.

## Summary

Users often paste a whole `curl`/`wget` command line straight into the job **URL** field (frequently with a trailing `> /dev/null`). Today that just gets saved as a broken URL. This PR detects the pasted command and offers a one-click **Import** that fills in the URL, request method, headers, body and basic auth — the same job fields the [Import from cURL dialog (#421)](https://github.com/pschlan/cron-job.org/pull/421) already populates.

When the text in the URL field parses to a command with a URL, an inline info banner appears under the field:

> **This looks like a cURL or wget command**
> Instead of using it as the URL, we can read the URL, request method, headers, body and authentication from it.  **[Import command]**

It's non-destructive — nothing changes until the user clicks Import — and it disappears as soon as the field no longer looks like a command.

## How it works

- **`frontend/src/utils/CommandParser.js`** (new), built on the existing `CurlParser` shell tokenizer so we don't add a dependency:
  - `looksLikeHttpCommand()` — cheap detector the URL field calls on change. Matches a leading `curl`/`wget` command word (tolerating a `$ `/`# ` prompt, `sudo`, env assignments and an executable path like `/usr/bin/curl`), but deliberately **not** a normal URL such as `https://curl.example.com` or `https://example.com/wget`.
  - `parseWget()` — wget's flags differ from curl's (`-O` takes a value, `-H` means span-hosts not header, `--post-data` implies POST, plus `--header` / `--method` / `--user` / `--password` / `--user-agent` / `--referer`), so it gets a dedicated parser rather than reusing curl's flag tables. The classic monitoring form `wget -q -O /dev/null https://example.com` parses correctly.
  - `parseHttpCommand()` — dispatches to the curl or wget parser and returns the shared `{ url, method, headers, body, auth }` shape.
- **`JobEditor.jsx`** — detection state + the inline banner. Importing reuses the existing apply path (renamed `applyImportedCurl` → `applyImportedCommand` since it now serves curl, wget and the dialog). Unsupported HTTP methods surface the same error message the dialog uses.
- Programmatic URL updates now **remount the URL field** (via a `key` bump) so the displayed value reflects the cleaned URL after an import — `ValidatingTextField` keeps its value in internal state and otherwise wouldn't pick up the change. This also fixes the display for the existing test-run "Update job URL" redirect path.
- English and German phrases for the banner (matching the German strings added after #421 was merged).

## Test plan

- [x] `cd frontend && npx react-scripts test --watchAll=false src/utils/CommandParser.test.js src/utils/CurlParser.test.js src/components/jobs/CurlImportDialog.test.jsx` — **84 / 84 passing**. The new `CommandParser.test.js` adds 26 tests covering the detector (including the false-positive guards for `https://curl.example.com` and `https://example.com/wget`), the wget parser (`-O /dev/null`, `--post-data` → POST + form content-type, `--method`, `--user`/`--password`, `-U`/`--user-agent`, `--referer`, glued `-O-`, sudo/env prefixes) and the curl/wget dispatch.
- [x] `cd frontend && npx react-scripts build` — clean build (+1.86 kB gzip), no new warnings.
- [x] `npx react-scripts start` boots with no new console errors (only the pre-existing `Footer.jsx` `validateDOMNesting` warnings on `master`).

## Notes for the reviewer

- The `key`-remount on the URL field is the smallest fix I found for the display-sync issue without touching the shared `ValidatingTextField`; happy to extract that into the component instead if you'd prefer.
- Scope is intentionally limited to the URL field. The sibling [#12 (paste crontab lines)](https://github.com/pschlan/cron-job.org/issues/12) is left out — the schedule side is a separate concern.
- End-to-end UI verification of the apply path needs the full backend (the editor route is auth-gated), so the behaviour is covered by the unit suite, same as #421.
