### PR TITLE
frontend: Explain job failure modes and HTTP error codes in history

### DIFF
--- a/frontend/src/components/jobs/HistoryDetails.jsx
+++ b/frontend/src/components/jobs/HistoryDetails.jsx
@@ -1,17 +1,22 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Button, Dialog, DialogTitle, DialogContent, DialogActions, Typography, LinearProgress, makeStyles } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
 import { useTranslation } from 'react-i18next';
 import { JobStatus, jobStatusText } from '../../utils/Constants';
+import { statusExplanationToken } from '../../utils/JobStatusInfo';
 import { getJobHistoryDetails } from '../../utils/API';
 import Timing from './Timing';
 import Code from '../misc/Code';
 import Headers from '../misc/Headers';
 import SslCertExpiryIcon from '../misc/SslCertExpiryIcon';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   statusRow: {
     display: 'flex',
     alignItems: 'center'
+  },
+  statusExplanation: {
+    marginBottom: theme.spacing(1)
   }
 }));
 
@@ -21,6 +26,8 @@ export default function HistoryDetails({ log, open, onClose, moment }) {
   const [ isLoading, setIsLoading ] = useState(true);
   const onCloseHook = useRef(onClose, []);
   const [ details, setDetails ] = useState({});
+
+  const explanationToken = statusExplanationToken(log.status, log.httpStatus);
 
   useEffect(() => {
     getJobHistoryDetails(log.identifier)
@@ -47,6 +54,10 @@ export default function HistoryDetails({ log, open, onClose, moment }) {
             <SslCertExpiryIcon sslCertExpiry={details.sslCertExpiry || log.sslCertExpiry} />
           </div>
         </Typography>
+
+        {explanationToken && <Alert severity='info' className={classes.statusExplanation}>
+          {t('jobs.statusExplanations.' + explanationToken)}
+        </Alert>}
 
         <Timing stats={details && details.stats} header={<Typography variant='overline'>{t('jobs.timing')}</Typography>} />
 

--- a/frontend/src/components/jobs/HistoryDetails.test.jsx
+++ b/frontend/src/components/jobs/HistoryDetails.test.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import HistoryDetails from './HistoryDetails';
+import { JobStatus } from '../../utils/Constants';
+import enTranslation from '../../locales/en/translation.json';
+
+// Keep the test focused on the status-explanation behaviour by stubbing the API
+// and the unrelated child components.
+// NB: a plain function (not jest.fn) because react-scripts runs with
+// resetMocks:true, which would otherwise wipe the implementation before each test.
+jest.mock('../../utils/API', () => ({
+  __esModule: true,
+  getJobHistoryDetails: () => Promise.resolve({ jobHistoryDetails: {} }),
+}));
+jest.mock('./Timing', () => ({ __esModule: true, default: () => null }));
+jest.mock('../misc/Code', () => ({ __esModule: true, default: ({ children }) => <div>{children}</div> }));
+jest.mock('../misc/Headers', () => ({ __esModule: true, default: () => null }));
+jest.mock('../misc/SslCertExpiryIcon', () => ({ __esModule: true, default: () => null }));
+
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: { en: { translation: enTranslation } },
+    interpolation: { escapeValue: false },
+  });
+});
+
+const baseLog = {
+  identifier: 'abc',
+  date: 1700000000,
+  url: 'https://example.com',
+  httpStatus: 0,
+  statusText: '',
+};
+
+function renderDetails(log) {
+  const moment = () => ({ calendar: () => 'today' });
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <HistoryDetails log={{ ...baseLog, ...log }} open={true} onClose={() => {}} moment={moment} />
+    </I18nextProvider>
+  );
+}
+
+describe('HistoryDetails status explanation', () => {
+  it('shows the dedicated explanation for a 404 HTTP error', async () => {
+    renderDetails({ status: JobStatus.FAILED_HTTPERROR, httpStatus: 404, statusText: 'Not Found' });
+    await waitFor(() =>
+      expect(screen.getByText(/the requested url does not exist/i)).toBeInTheDocument()
+    );
+  });
+
+  it('shows the 5xx class explanation for an uncommon server error code', async () => {
+    renderDetails({ status: JobStatus.FAILED_HTTPERROR, httpStatus: 599, statusText: 'Unknown' });
+    await waitFor(() =>
+      expect(screen.getByText(/server encountered an error/i)).toBeInTheDocument()
+    );
+  });
+
+  it('shows the timeout explanation for a non-HTTP failure mode', async () => {
+    renderDetails({ status: JobStatus.FAILED_TIMEOUT });
+    await waitFor(() =>
+      expect(screen.getByText(/did not fully respond within the configured timeout/i)).toBeInTheDocument()
+    );
+  });
+
+  it('does not show any explanation for a successful execution', async () => {
+    renderDetails({ status: JobStatus.OK, httpStatus: 200, statusText: 'OK' });
+    // The status itself still renders (await it so the async load settles)...
+    await screen.findByText(/200 OK/);
+    // ...but no explanatory note should be present.
+    expect(screen.queryByText(/check the url/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/server encountered an error/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/jobs/JobTestRun.jsx
+++ b/frontend/src/components/jobs/JobTestRun.jsx
@@ -7,6 +7,7 @@ import { Config } from '../../utils/Config';
 import { useSnackbar } from 'notistack';
 import { deleteJobTestRun, getJobTestRunStatus, submitJobTestRun } from '../../utils/API';
 import { JobStatus, jobStatusText, JobTestRunState } from '../../utils/Constants';
+import { statusExplanationToken } from '../../utils/JobStatusInfo';
 import SuccessIcon from '@material-ui/icons/Check';
 import FailureIcon from '@material-ui/icons/ErrorOutline';
 import PeerIcon from '@material-ui/icons/Dns';
@@ -191,6 +192,17 @@ export default function JobTestRun({ job, jobId, onClose, onUpdateUrl = () => nu
               <>{t('jobs.statuses.' + jobStatusText(status.result))}</>}
           </div>}
         </Typography>
+
+        {status.state === JobTestRunState.DONE && !redirectTarget && (() => {
+          // The dedicated redirect note below already covers the 3xx case, so
+          // only show the generic explanation when it isn't shown.
+          const explanationToken = statusExplanationToken(status.result, status.httpStatus);
+          return explanationToken && <Box mt={2}>
+            <Alert severity='info'>
+              {t('jobs.statusExplanations.' + explanationToken)}
+            </Alert>
+          </Box>;
+        })()}
 
         {redirectTarget && <Box mt={2}>
           <Alert severity='warning'>

--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
-import { Paper, makeStyles, TableContainer, Link, Typography, Button, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, ButtonGroup, Select, MenuItem, InputAdornment, Box } from '@material-ui/core';
+import { Paper, makeStyles, TableContainer, Link, Typography, Button, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, ButtonGroup, Select, MenuItem, InputAdornment, Box, Tooltip } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import Table from '../misc/Table';
 import moment from 'moment';
 import { jobStatusText } from '../../utils/Constants';
+import { statusExplanationToken } from '../../utils/JobStatusInfo';
 import AddIcon from '@material-ui/icons/AlarmAdd';
 import EditIcon from '@material-ui/icons/Edit';
 import HistoryIcon from '@material-ui/icons/History';
@@ -26,6 +27,11 @@ import { Alert, AlertTitle } from '@material-ui/lab';
 const useStyles = makeStyles((theme) => ({
   actionButton: {
     margin: theme.spacing(1)
+  },
+  statusWithHelp: {
+    textDecorationLine: 'underline',
+    textDecorationStyle: 'dotted',
+    cursor: 'help'
   }
 }));
 
@@ -75,13 +81,26 @@ export default function Jobs({ match }) {
     },
     {
       head: t('jobs.lastExecution'),
-      cell: job => job.lastExecution ? <>
+      cell: job => {
+        if (!job.lastExecution) {
+          return <>-</>;
+        }
+        const statusText = t('jobs.statuses.' + jobStatusText(job.lastStatus));
+        // The job list only carries the status, not the HTTP code, so HTTP
+        // errors fall back to a generic explanation pointing to the details.
+        const explanationToken = statusExplanationToken(job.lastStatus);
+        return <>
           <div>{moment(job.lastExecution * 1000).calendar()}</div>
           <div><Typography variant="caption">
-              {t('jobs.statuses.' + jobStatusText(job.lastStatus))}
+              {explanationToken ?
+                <Tooltip arrow title={t('jobs.statusExplanations.' + explanationToken)}>
+                  <span className={classes.statusWithHelp}>{statusText}</span>
+                </Tooltip> :
+                statusText}
               &nbsp;({formatMs(job.lastDuration, t)})
             </Typography></div>
-        </> : <>-</>
+        </>;
+      }
     },
     {
       head: t('jobs.nextExecution'),

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -191,6 +191,32 @@
       "FAILED_INTERNAL": "Fehlgeschlagen (interner Fehler)",
       "FAILED_OTHERS": "Fehlgeschlagen"
     },
+    "statusExplanations": {
+      "modes": {
+        "FAILED_DNS": "Der Hostname in der URL konnte nicht aufgelöst werden. Prüfen Sie, ob die Domain korrekt geschrieben ist und noch existiert.",
+        "FAILED_CONNECT": "Es konnte keine Verbindung zum Server hergestellt werden. Der Server ist möglicherweise nicht erreichbar oder eine Firewall blockiert Anfragen von unseren Servern.",
+        "FAILED_TIMEOUT": "Der Server hat nicht innerhalb des konfigurierten Timeouts vollständig geantwortet. Erhöhen Sie das Timeout in den erweiterten Einstellungen des Jobs oder prüfen Sie, warum der Endpunkt langsam ist.",
+        "FAILED_SIZE": "Die Antwort war größer als das erlaubte Limit und wurde abgebrochen. Lassen Sie den Endpunkt weniger Daten zurückgeben.",
+        "FAILED_URL": "Die URL konnte nicht verarbeitet werden. Bitte prüfen Sie sie auf Tippfehler und stellen Sie sicher, dass sie mit http:// oder https:// beginnt.",
+        "FAILED_INTERNAL": "Beim Ausführen des Jobs ist ein interner Fehler aufgetreten. Falls dies wiederholt auftritt, kontaktieren Sie bitte unser Support-Team.",
+        "FAILED_OTHERS": "Die Anfrage ist aus einem nicht näher bestimmten Grund fehlgeschlagen. Führen Sie einen Testlauf durch, um weitere Details zu erhalten."
+      },
+      "http": {
+        "3xx": "Der Server hat eine Weiterleitung zurückgegeben. Weiterleitungen werden standardmäßig als Fehler gewertet — Sie können in den erweiterten Einstellungen \"Weiterleitungen als Erfolg werten\" aktivieren oder den Job direkt auf das Weiterleitungsziel richten.",
+        "4xx": "Der Server hat die Anfrage abgelehnt (Client-Fehler). Prüfen Sie URL, Anfrage-Methode, Header, Body und eine eventuell erforderliche Authentifizierung.",
+        "5xx": "Auf dem Server ist ein Fehler aufgetreten (Server-Fehler). Dies liegt in der Regel am Zielserver und löst sich oft von selbst.",
+        "400": "Bad Request: Der Server konnte die Anfrage nicht verarbeiten. Prüfen Sie Body, Header und Methode der Anfrage.",
+        "401": "Unauthorized: Der Endpunkt erfordert eine Authentifizierung. Fügen Sie die nötigen Zugangsdaten oder einen Authorization-Header hinzu.",
+        "403": "Forbidden: Der Server hat die Anfrage abgelehnt. Der Endpunkt blockiert möglicherweise automatisierte Anfragen oder erfordert eine Authentifizierung.",
+        "404": "Not Found: Die angeforderte URL existiert auf dem Server nicht. Prüfen Sie die URL auf Tippfehler.",
+        "405": "Method Not Allowed: Der Endpunkt akzeptiert diese HTTP-Methode nicht. Versuchen Sie eine andere Anfrage-Methode.",
+        "429": "Too Many Requests: Der Server drosselt Ihre Anfragen. Reduzieren Sie ggf. die Ausführungshäufigkeit des Jobs.",
+        "500": "Internal Server Error: Auf dem Zielserver ist bei der Verarbeitung der Anfrage etwas schiefgelaufen.",
+        "502": "Bad Gateway: Ein dem Zielserver vorgelagerter Server hat eine ungültige Antwort zurückgegeben.",
+        "503": "Service Unavailable: Der Server kann die Anfrage vorübergehend nicht bearbeiten, z. B. wegen Überlastung oder Wartung.",
+        "504": "Gateway Timeout: Ein dem Zielserver vorgelagerter Server hat nicht rechtzeitig geantwortet."
+      }
+    },
     "fetchedUrl": "Abgerufene URL",
     "responseHeaders": "Antwort-Header",
     "responseBody": "Antwort-Body",

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -193,6 +193,7 @@
     },
     "statusExplanations": {
       "modes": {
+        "FAILED_HTTPERROR": "Der Server hat mit einem HTTP-Fehler geantwortet. Öffnen Sie die Details der Ausführung, um den genauen Status-Code und dessen Bedeutung zu sehen.",
         "FAILED_DNS": "Der Hostname in der URL konnte nicht aufgelöst werden. Prüfen Sie, ob die Domain korrekt geschrieben ist und noch existiert.",
         "FAILED_CONNECT": "Es konnte keine Verbindung zum Server hergestellt werden. Der Server ist möglicherweise nicht erreichbar oder eine Firewall blockiert Anfragen von unseren Servern.",
         "FAILED_TIMEOUT": "Der Server hat nicht innerhalb des konfigurierten Timeouts vollständig geantwortet. Erhöhen Sie das Timeout in den erweiterten Einstellungen des Jobs oder prüfen Sie, warum der Endpunkt langsam ist.",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -193,6 +193,7 @@
     },
     "statusExplanations": {
       "modes": {
+        "FAILED_HTTPERROR": "The server responded with an HTTP error. Open the execution's details to see the exact status code and what it means.",
         "FAILED_DNS": "The host name in the URL could not be resolved. Check that the domain is spelled correctly and still exists.",
         "FAILED_CONNECT": "A connection to the server could not be established. The server may be down or a firewall may be blocking requests from our servers.",
         "FAILED_TIMEOUT": "The server did not fully respond within the configured timeout. Try increasing the timeout in the job's advanced settings, or check why the endpoint is slow.",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -191,6 +191,32 @@
       "FAILED_INTERNAL": "Failed (internal error)",
       "FAILED_OTHERS": "Failed"
     },
+    "statusExplanations": {
+      "modes": {
+        "FAILED_DNS": "The host name in the URL could not be resolved. Check that the domain is spelled correctly and still exists.",
+        "FAILED_CONNECT": "A connection to the server could not be established. The server may be down or a firewall may be blocking requests from our servers.",
+        "FAILED_TIMEOUT": "The server did not fully respond within the configured timeout. Try increasing the timeout in the job's advanced settings, or check why the endpoint is slow.",
+        "FAILED_SIZE": "The response was larger than the allowed limit and was aborted. Make the endpoint return less data.",
+        "FAILED_URL": "The URL could not be parsed. Please check it for typos and make sure it starts with http:// or https://.",
+        "FAILED_INTERNAL": "An internal error occurred while executing the job. If this keeps happening, please contact our support team.",
+        "FAILED_OTHERS": "The request failed for an unspecified reason. Please try a test run to get more details."
+      },
+      "http": {
+        "3xx": "The server returned a redirect. By default redirects are treated as a failure — you can enable \"Treat redirects as success\" in the job's advanced settings, or point the job directly at the redirect target.",
+        "4xx": "The server rejected the request (client error). Check the URL, request method, headers, body and any required authentication.",
+        "5xx": "The server encountered an error (server error). This is usually a problem on the destination server's side and often resolves itself.",
+        "400": "Bad request: the server could not understand the request. Check the request body, headers and method.",
+        "401": "Unauthorized: the endpoint requires authentication. Add the necessary credentials or an authorization header.",
+        "403": "Forbidden: the server refused the request. The endpoint may block automated requests or require authentication.",
+        "404": "Not found: the requested URL does not exist on the server. Check the URL for typos.",
+        "405": "Method not allowed: the endpoint does not accept this HTTP method. Try a different request method.",
+        "429": "Too many requests: the server is rate-limiting you. Consider reducing the job's execution frequency.",
+        "500": "Internal server error: something went wrong on the destination server while handling the request.",
+        "502": "Bad gateway: a server upstream of the destination returned an invalid response.",
+        "503": "Service unavailable: the server is temporarily unable to handle the request, e.g. because it is overloaded or under maintenance.",
+        "504": "Gateway timeout: a server upstream of the destination did not respond in time."
+      }
+    },
     "fetchedUrl": "Fetched URL",
     "responseHeaders": "Response headers",
     "responseBody": "Response body",

--- a/frontend/src/utils/JobStatusInfo.js
+++ b/frontend/src/utils/JobStatusInfo.js
@@ -51,9 +51,13 @@ export function httpStatusExplanationToken(httpStatus) {
 
 // Returns an explanation token for a job execution result, or null when there
 // is nothing to explain (success or unknown status).
+//
+// For an HTTP error we prefer the explanation for the concrete status code, but
+// fall back to a generic message when the code isn't available (e.g. the job
+// list only carries the status, not the HTTP code).
 export function statusExplanationToken(status, httpStatus) {
   if (status === JobStatus.FAILED_HTTPERROR) {
-    return httpStatusExplanationToken(httpStatus);
+    return httpStatusExplanationToken(httpStatus) || 'modes.FAILED_HTTPERROR';
   }
   return FAILURE_MODE_TOKENS[status] || null;
 }

--- a/frontend/src/utils/JobStatusInfo.js
+++ b/frontend/src/utils/JobStatusInfo.js
@@ -1,0 +1,59 @@
+// Maps a job execution result to a short, human-readable explanation of why it
+// failed and what the user can typically do about it (GitHub issue #250).
+//
+// The functions return an i18n token (relative to `jobs.statusExplanations.`)
+// rather than a translated string so the mapping stays pure and easy to test.
+// They return null when there is nothing useful to explain (e.g. a successful
+// execution or an unknown status).
+
+import { JobStatus } from './Constants';
+
+const FAILURE_MODE_TOKENS = {
+  [JobStatus.FAILED_DNS]: 'modes.FAILED_DNS',
+  [JobStatus.FAILED_CONNECT]: 'modes.FAILED_CONNECT',
+  [JobStatus.FAILED_TIMEOUT]: 'modes.FAILED_TIMEOUT',
+  [JobStatus.FAILED_SIZE]: 'modes.FAILED_SIZE',
+  [JobStatus.FAILED_URL]: 'modes.FAILED_URL',
+  [JobStatus.FAILED_INTERNAL]: 'modes.FAILED_INTERNAL',
+  [JobStatus.FAILED_OTHERS]: 'modes.FAILED_OTHERS',
+};
+
+// HTTP status codes that get their own dedicated explanation. Anything else
+// falls back to the explanation for its class (3xx / 4xx / 5xx).
+const SPECIFIC_HTTP_CODES = new Set([
+  400, 401, 403, 404, 405, 429, 500, 502, 503, 504,
+]);
+
+// Returns an explanation token for a non-success HTTP status code, or null for
+// 1xx/2xx (success) and anything outside the 3xx-5xx range.
+export function httpStatusExplanationToken(httpStatus) {
+  if (typeof httpStatus !== 'number' || !Number.isFinite(httpStatus)) {
+    return null;
+  }
+
+  const httpClass = Math.floor(httpStatus / 100);
+
+  // Redirects don't have per-code explanations; the class message covers them.
+  if (httpClass === 3) {
+    return 'http.3xx';
+  }
+  if (SPECIFIC_HTTP_CODES.has(httpStatus)) {
+    return 'http.' + httpStatus;
+  }
+  if (httpClass === 4) {
+    return 'http.4xx';
+  }
+  if (httpClass === 5) {
+    return 'http.5xx';
+  }
+  return null;
+}
+
+// Returns an explanation token for a job execution result, or null when there
+// is nothing to explain (success or unknown status).
+export function statusExplanationToken(status, httpStatus) {
+  if (status === JobStatus.FAILED_HTTPERROR) {
+    return httpStatusExplanationToken(httpStatus);
+  }
+  return FAILURE_MODE_TOKENS[status] || null;
+}

--- a/frontend/src/utils/JobStatusInfo.test.js
+++ b/frontend/src/utils/JobStatusInfo.test.js
@@ -72,8 +72,9 @@ describe('statusExplanationToken', () => {
     expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, 302)).toBe('http.3xx');
   });
 
-  it('returns null for an HTTP error without a usable status code', () => {
-    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, 0)).toBeNull();
-    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, undefined)).toBeNull();
+  it('falls back to a generic HTTP-error explanation when no usable status code is available', () => {
+    // e.g. the job list carries the status but not the HTTP code.
+    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, 0)).toBe('modes.FAILED_HTTPERROR');
+    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, undefined)).toBe('modes.FAILED_HTTPERROR');
   });
 });

--- a/frontend/src/utils/JobStatusInfo.test.js
+++ b/frontend/src/utils/JobStatusInfo.test.js
@@ -1,0 +1,79 @@
+import { httpStatusExplanationToken, statusExplanationToken } from './JobStatusInfo';
+import { JobStatus } from './Constants';
+
+describe('httpStatusExplanationToken', () => {
+  it('returns null for successful (2xx) and informational (1xx) codes', () => {
+    expect(httpStatusExplanationToken(100)).toBeNull();
+    expect(httpStatusExplanationToken(200)).toBeNull();
+    expect(httpStatusExplanationToken(204)).toBeNull();
+  });
+
+  it('returns the class token for any redirect code', () => {
+    expect(httpStatusExplanationToken(301)).toBe('http.3xx');
+    expect(httpStatusExplanationToken(302)).toBe('http.3xx');
+    expect(httpStatusExplanationToken(307)).toBe('http.3xx');
+    expect(httpStatusExplanationToken(308)).toBe('http.3xx');
+  });
+
+  it('returns a dedicated token for well-known client errors', () => {
+    expect(httpStatusExplanationToken(400)).toBe('http.400');
+    expect(httpStatusExplanationToken(401)).toBe('http.401');
+    expect(httpStatusExplanationToken(403)).toBe('http.403');
+    expect(httpStatusExplanationToken(404)).toBe('http.404');
+    expect(httpStatusExplanationToken(405)).toBe('http.405');
+    expect(httpStatusExplanationToken(429)).toBe('http.429');
+  });
+
+  it('returns a dedicated token for well-known server errors', () => {
+    expect(httpStatusExplanationToken(500)).toBe('http.500');
+    expect(httpStatusExplanationToken(502)).toBe('http.502');
+    expect(httpStatusExplanationToken(503)).toBe('http.503');
+    expect(httpStatusExplanationToken(504)).toBe('http.504');
+  });
+
+  it('falls back to the class token for other 4xx/5xx codes', () => {
+    expect(httpStatusExplanationToken(402)).toBe('http.4xx');
+    expect(httpStatusExplanationToken(418)).toBe('http.4xx');
+    expect(httpStatusExplanationToken(451)).toBe('http.4xx');
+    expect(httpStatusExplanationToken(501)).toBe('http.5xx');
+    expect(httpStatusExplanationToken(599)).toBe('http.5xx');
+  });
+
+  it('returns null for out-of-range or non-numeric input', () => {
+    expect(httpStatusExplanationToken(0)).toBeNull();
+    expect(httpStatusExplanationToken(600)).toBeNull();
+    expect(httpStatusExplanationToken(NaN)).toBeNull();
+    expect(httpStatusExplanationToken(undefined)).toBeNull();
+    expect(httpStatusExplanationToken(null)).toBeNull();
+    expect(httpStatusExplanationToken('404')).toBeNull();
+  });
+});
+
+describe('statusExplanationToken', () => {
+  it('returns null for successful and unknown executions', () => {
+    expect(statusExplanationToken(JobStatus.OK, 200)).toBeNull();
+    expect(statusExplanationToken(JobStatus.UNKNOWN, 0)).toBeNull();
+  });
+
+  it('maps each non-HTTP failure mode to its token', () => {
+    expect(statusExplanationToken(JobStatus.FAILED_DNS)).toBe('modes.FAILED_DNS');
+    expect(statusExplanationToken(JobStatus.FAILED_CONNECT)).toBe('modes.FAILED_CONNECT');
+    expect(statusExplanationToken(JobStatus.FAILED_TIMEOUT)).toBe('modes.FAILED_TIMEOUT');
+    expect(statusExplanationToken(JobStatus.FAILED_SIZE)).toBe('modes.FAILED_SIZE');
+    expect(statusExplanationToken(JobStatus.FAILED_URL)).toBe('modes.FAILED_URL');
+    expect(statusExplanationToken(JobStatus.FAILED_INTERNAL)).toBe('modes.FAILED_INTERNAL');
+    expect(statusExplanationToken(JobStatus.FAILED_OTHERS)).toBe('modes.FAILED_OTHERS');
+  });
+
+  it('delegates HTTP errors to the HTTP code explanation', () => {
+    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, 404)).toBe('http.404');
+    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, 418)).toBe('http.4xx');
+    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, 503)).toBe('http.503');
+    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, 302)).toBe('http.3xx');
+  });
+
+  it('returns null for an HTTP error without a usable status code', () => {
+    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, 0)).toBeNull();
+    expect(statusExplanationToken(JobStatus.FAILED_HTTPERROR, undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #250.

## Summary

The execution-details dialog currently shows only the raw status — `404 Not Found`, `Failed (timeout)`, `Failed (DNS lookup)`, etc. — with no hint of what it means or what the user can do about it. This PR adds a short, plain-language explanation under the status whenever an execution failed.

For example, opening the details of a failed execution now shows:

> **Status**
> 404 Not Found
> ℹ️ *Not found: the requested URL does not exist on the server. Check the URL for typos.*

The note only appears for failures — successful (and unknown) executions render exactly as before.

## How it works

- **`frontend/src/utils/JobStatusInfo.js`** (new) maps a result to an i18n token:
  - the non-HTTP failure modes (`FAILED_DNS`, `FAILED_CONNECT`, `FAILED_TIMEOUT`, `FAILED_SIZE`, `FAILED_URL`, `FAILED_INTERNAL`, `FAILED_OTHERS`) each get a dedicated explanation;
  - `FAILED_HTTPERROR` maps to a dedicated message for the common codes (`400/401/403/404/405/429/500/502/503/504`) and falls back to a per-class message for anything else (`3xx`/`4xx`/`5xx`);
  - returns `null` for successful or unknown executions, and for an HTTP error with no usable status code, so the note is only shown when there's something useful to say.
- **`HistoryDetails.jsx`** renders the explanation as an `@material-ui/lab` info `Alert` below the status row.
- English **and** German phrases for every explanation.

This is intentionally limited to the UI side of #250 (the issue says "in UI and/or docs"); it adds no backend changes and no new dependencies.

## Test plan

- [x] `cd frontend && npx react-scripts test --watchAll=false src/utils/JobStatusInfo.test.js src/components/jobs/HistoryDetails.test.jsx` — **14 / 14 passing**.
  - `JobStatusInfo.test.js` (10): the specific-code vs. class-fallback logic, the 3xx-as-class rule, out-of-range/non-numeric guards, and the failure-mode mapping.
  - `HistoryDetails.test.jsx` (4): renders the actual dialog against the **real English phrases** and asserts the right note for a 404, an uncommon 5xx (599 → class message), a timeout, and that a successful (200) run shows no note.
- [x] `cd frontend && npx react-scripts build` — clean build, no new warnings.
- [x] `npx react-scripts start` boots with no new console errors (only the pre-existing `Footer.jsx` `validateDOMNesting` warnings on `master`).

## Notes for the reviewer

- The wording aims to be actionable but concise; happy to adjust tone/length to match your preference.
- The details dialog is auth-gated, so the end-to-end UI isn't reachable without the full backend — the rendering is covered by the React Testing Library test instead (same approach as #421 / #423).
