### PR TITLE
Only send onSuccess notification after a notified failure

### DIFF
--- a/chronos/UpdateThread.cpp
+++ b/chronos/UpdateThread.cpp
@@ -337,8 +337,8 @@ void UpdateThread::storeResult(const std::unique_ptr<JobResult> &result)
 			&& result->status == JOBSTATUS_OK
 			&& oldFailCounter > 0
 			&& failCounter == 0
-			&& result->notifyFailure
-			&& oldUnfilteredFailCounter >= result->notifyFailureCount)
+			&& (!result->notifyFailure || 
+				oldUnfilteredFailCounter >= result->notifyFailureCount)
 		{
 			createNotification 			= true;
 			notificationType 			= NOTIFICATION_TYPE_SUCCESS;

--- a/chronos/UpdateThread.cpp
+++ b/chronos/UpdateThread.cpp
@@ -336,7 +336,9 @@ void UpdateThread::storeResult(const std::unique_ptr<JobResult> &result)
 		if(result->notifySuccess
 			&& result->status == JOBSTATUS_OK
 			&& oldFailCounter > 0
-			&& failCounter == 0)
+			&& failCounter == 0
+			&& result->notifyFailure
+			&& oldUnfilteredFailCounter >= result->notifyFailureCount)
 		{
 			createNotification 			= true;
 			notificationType 			= NOTIFICATION_TYPE_SUCCESS;


### PR DESCRIPTION
I use cron-job.org and I have a few low reliability crons. For that ones I turned on the failing count before being notified. Anyway I get notified of success after a former failure every time a cron fails even if it hasn't reached the failure count notification and so, I'm not aware about the failure.

I think the success notification should be sent only if a failure notification has been sent.

This PR ensure that the onSuccess notification is only sent if a failure notification was actually triggered. It verifies that notifyFailure is enabled and the consecutive failure count is greater than or equal to notifyFailureCount.

Ps. Thanks for Your job!