### PR TITLE
frontend: Parse crontab lines to populate schedule and request fields

### DIFF
--- a/frontend/src/components/jobs/CurlImportDialog.jsx
+++ b/frontend/src/components/jobs/CurlImportDialog.jsx
@@ -7,6 +7,7 @@ import {
 import { Alert } from '@material-ui/lab';
 
 import { parseCurl } from '../../utils/CurlParser';
+import { parseHttpCommand, parseCrontabLine } from '../../utils/CommandParser';
 import { RequestMethod } from '../../utils/Constants';
 
 const useStyles = makeStyles(() => ({
@@ -33,7 +34,17 @@ export default function CurlImportDialog({ open, onClose, onImport }) {
   }
 
   function doImport() {
-    const parsed = parseCurl(command);
+    let parsed = null;
+    let schedule = null;
+
+    const crontabResult = parseCrontabLine(command);
+    if (crontabResult) {
+      parsed = crontabResult.command;
+      schedule = crontabResult.schedule;
+    } else {
+      parsed = parseHttpCommand(command) || parseCurl(command);
+    }
+
     if (!parsed) {
       setError(t('jobs.curlImport.parseError'));
       return;
@@ -55,6 +66,7 @@ export default function CurlImportDialog({ open, onClose, onImport }) {
       headers: parsed.headers,
       body: parsed.body,
       auth: parsed.auth,
+      schedule,
     });
     setCommand('');
     setError(null);
@@ -69,7 +81,7 @@ export default function CurlImportDialog({ open, onClose, onImport }) {
         label={t('jobs.curlImport.command')}
         value={command}
         onChange={({target}) => { setCommand(target.value); setError(null); }}
-        placeholder={"curl -X POST 'https://example.com/api' -H 'Accept: application/json' -d 'name=ada'"}
+        placeholder={"curl -X POST 'https://example.com/api' -H 'Accept: application/json' -d 'name=ada'\n\n# or a crontab line:\n*/5 * * * * curl https://example.com/api"}
         multiline
         minRows={8}
         maxRows={16}

--- a/frontend/src/components/jobs/JobEditor.jsx
+++ b/frontend/src/components/jobs/JobEditor.jsx
@@ -23,7 +23,7 @@ import {
   RequestMethod,
   RequestMethodsSupportingCustomBody
 } from '../../utils/Constants';
-import { looksLikeHttpCommand, parseHttpCommand } from '../../utils/CommandParser';
+import { looksLikeHttpCommand, parseHttpCommand, looksLikeCrontabLine, parseCrontabLine } from '../../utils/CommandParser';
 import useTimezones from '../../hooks/useTimezones';
 import NotFound from '../misc/NotFound';
 import Breadcrumbs from '../misc/Breadcrumbs';
@@ -147,6 +147,8 @@ export default function JobEditor({ match }) {
   const [ requestBody, setRequestBody ] = useState('');
   const [ jobHeaders, setJobHeaders ] = useState([]);
   const [ schedule, setSchedule ] = useState({});
+  const [ scheduleOverride, setScheduleOverride ] = useState(null);
+  const [ scheduleKey, setScheduleKey ] = useState(0);
   const [ timezone, setTimezone ] = useState();
   const [ jobFolderId, setJobFolderId ] = useState();
   const [ tabValue, setTabValue ] = useState('common');
@@ -404,7 +406,14 @@ export default function JobEditor({ match }) {
   // Detect a curl/wget command pasted into the URL field and remember the parsed
   // result so we can offer a one-click import (GitHub issue #103).
   function detectCommandInUrl(value) {
-    if (looksLikeHttpCommand(value)) {
+    if (looksLikeCrontabLine(value)) {
+      const parsed = parseCrontabLine(value);
+      if (parsed && parsed.command && parsed.command.url) {
+        setDetectedCommand({ ...parsed.command, _schedule: parsed.schedule });
+      } else {
+        setDetectedCommand(null);
+      }
+    } else if (looksLikeHttpCommand(value)) {
       const parsed = parseHttpCommand(value);
       setDetectedCommand(parsed && parsed.url ? parsed : null);
     } else {
@@ -433,6 +442,7 @@ export default function JobEditor({ match }) {
       headers: detectedCommand.headers,
       body: detectedCommand.body,
       auth: detectedCommand.auth,
+      schedule: detectedCommand._schedule || null,
     });
     setDetectedCommand(null);
   }
@@ -446,7 +456,7 @@ export default function JobEditor({ match }) {
     return url;
   }
 
-  function applyImportedCommand({ url, method, headers, body, auth }) {
+  function applyImportedCommand({ url, method, headers, body, auth, schedule: importedSchedule }) {
     if (url) updateUrl(url);
     if (method !== null && method !== undefined) setRequestMethod(method);
     setJobHeaders(headers || []);
@@ -464,6 +474,11 @@ export default function JobEditor({ match }) {
       if (authPasswordRef.current) authPasswordRef.current.value = auth.password || '';
     }
 
+    if (importedSchedule) {
+      setScheduleOverride(importedSchedule);
+      setScheduleKey(k => k + 1);
+    }
+
     setTabValue('common');
     setShowCurlImport(false);
 
@@ -473,6 +488,7 @@ export default function JobEditor({ match }) {
     if (headers && headers.length > 0) parts.push(t('jobs.curlImport.appliedParts.headers', { count: headers.length }));
     if (body) parts.push(t('jobs.curlImport.appliedParts.body'));
     if (auth) parts.push(t('jobs.curlImport.appliedParts.auth'));
+    if (importedSchedule) parts.push(t('jobs.curlImport.appliedParts.schedule'));
     enqueueSnackbar(t('jobs.curlImport.applied', { parts: parts.join(', ') }), { variant: 'success' });
   }
 
@@ -603,9 +619,9 @@ export default function JobEditor({ match }) {
             />
           {detectedCommand && <Box mb={2}>
             <Alert severity='info'>
-              <AlertTitle>{t('jobs.commandImport.title')}</AlertTitle>
+              <AlertTitle>{t(detectedCommand._schedule ? 'jobs.crontabImport.title' : 'jobs.commandImport.title')}</AlertTitle>
               <div>
-                {t('jobs.commandImport.text')}
+                {t(detectedCommand._schedule ? 'jobs.crontabImport.text' : 'jobs.commandImport.text')}
               </div>
               <Box mt={1}>
                 <Button
@@ -652,7 +668,7 @@ export default function JobEditor({ match }) {
 
         <fieldset className={classes.fieldSet}>
           <FormLabel component='legend'>{t('jobs.executionSchedule')}</FormLabel>
-          <JobSchedule initialSchedule={job.schedule || {}} timezone={timezone} onChange={sched => setSchedule(sched)} />
+          <JobSchedule key={scheduleKey} initialSchedule={scheduleOverride || job.schedule || {}} timezone={timezone} onChange={sched => setSchedule(sched)} />
         </fieldset>
 
         <fieldset className={classes.fieldSet}>

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -322,25 +322,30 @@
     "curlImport": {
       "button": "cURL-Befehl importieren",
       "title": "cURL-Befehl importieren",
-      "help": "Fügen Sie einen cURL-Befehl ein. Wir füllen daraus die Felder für URL, Anfrage-Methode, Header, Anfrage-Body und Authentifizierung aus.",
-      "command": "cURL-Befehl",
+      "help": "Fügen Sie einen cURL- oder wget-Befehl oder eine vollständige Crontab-Zeile ein. Wir füllen daraus die Felder für URL, Anfrage-Methode, Header, Anfrage-Body, Authentifizierung und Ausführungsplan aus.",
+      "command": "Befehl oder Crontab-Zeile",
       "import": "Importieren",
-      "parseError": "Wir konnten in Ihrer Eingabe keinen cURL-Befehl erkennen. Bitte stellen Sie sicher, dass er mit 'curl' beginnt und eine URL enthält.",
+      "parseError": "Wir konnten in Ihrer Eingabe keinen cURL-/wget-Befehl oder keine Crontab-Zeile erkennen. Bitte stellen Sie sicher, dass er mit 'curl' oder 'wget' beginnt (optional mit Cron-Zeitplan davor) und eine URL enthält.",
       "unsupportedMethod": "Die Anfrage-Methode '{{method}}' wird nicht unterstützt. Bitte wählen Sie eine unterstützte Methode manuell aus.",
-      "applied": "Aus cURL importiert: {{parts}}.",
+      "applied": "Importiert: {{parts}}.",
       "appliedParts": {
         "url": "URL",
         "method": "Anfrage-Methode",
         "headers": "{{count}} Header",
         "headers_plural": "{{count}} Header",
         "body": "Anfrage-Body",
-        "auth": "Authentifizierung"
+        "auth": "Authentifizierung",
+        "schedule": "Ausführungsplan"
       }
     },
     "commandImport": {
       "title": "Das sieht nach einem cURL- oder wget-Befehl aus",
       "text": "Statt ihn als URL zu verwenden, können wir daraus die URL, die Anfrage-Methode, Header, den Anfrage-Body und die Authentifizierung auslesen.",
       "import": "Befehl importieren"
+    },
+    "crontabImport": {
+      "title": "Das sieht nach einer Crontab-Zeile aus",
+      "text": "Wir können daraus den Ausführungsplan sowie die URL, die Anfrage-Methode, Header, den Anfrage-Body und die Authentifizierung auslesen."
     },
     "testRun": {
       "testRun": "Testlauf",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -322,25 +322,30 @@
     "curlImport": {
       "button": "Import from cURL",
       "title": "Import from cURL",
-      "help": "Paste a cURL command. We will populate the URL, request method, headers, body and authentication fields from it.",
-      "command": "cURL command",
+      "help": "Paste a cURL or wget command, or a full crontab line. We will populate the URL, request method, headers, body, authentication and schedule fields from it.",
+      "command": "Command or crontab line",
       "import": "Import",
-      "parseError": "We couldn't recognize a cURL command in your input. Please make sure it starts with 'curl' and contains a URL.",
+      "parseError": "We couldn't recognize a cURL/wget command or crontab line in your input. Please make sure it starts with 'curl' or 'wget' (optionally preceded by a cron schedule) and contains a URL.",
       "unsupportedMethod": "The request method '{{method}}' is not supported. Please pick a supported method manually.",
-      "applied": "Imported from cURL: {{parts}}.",
+      "applied": "Imported: {{parts}}.",
       "appliedParts": {
         "url": "URL",
         "method": "request method",
         "headers": "{{count}} header",
         "headers_plural": "{{count}} headers",
         "body": "request body",
-        "auth": "authentication"
+        "auth": "authentication",
+        "schedule": "execution schedule"
       }
     },
     "commandImport": {
       "title": "This looks like a cURL or wget command",
       "text": "Instead of using it as the URL, we can read the URL, request method, headers, body and authentication from it.",
       "import": "Import command"
+    },
+    "crontabImport": {
+      "title": "This looks like a crontab line",
+      "text": "We can read the execution schedule and the URL, request method, headers, body and authentication from it."
     },
     "testRun": {
       "testRun": "Test run",

--- a/frontend/src/utils/CommandParser.js
+++ b/frontend/src/utils/CommandParser.js
@@ -15,6 +15,7 @@
 //   }
 
 import { tokenize, parseCurl } from './CurlParser';
+import { crontabExpressionToSchedule } from './CrontabExpression';
 
 // Cheap check used by the UI to decide whether to offer an import. Matches a
 // leading `curl`/`wget` command word, tolerating a `$ `/`# ` prompt, a `sudo`
@@ -240,8 +241,47 @@ export function parseWget(input) {
   return result;
 }
 
-// Parse an HTTP command line, auto-detecting whether it is curl or wget.
-// Returns the unified shape or null when nothing usable could be extracted.
+const CRON_FIELD_RE = /^(?:\*(?:\/\d+)?|\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*)$/;
+
+export function looksLikeCrontabLine(input) {
+  if (typeof input !== 'string') return false;
+  const parts = input.trim().split(/\s+/);
+  if (parts.length < 6) return false;
+  for (let i = 0; i < 5; i++) {
+    if (!CRON_FIELD_RE.test(parts[i])) return false;
+  }
+  let idx = 0;
+  const trimmed = input.trim();
+  for (let i = 0; i < 5; i++) {
+    idx = trimmed.indexOf(parts[i], idx) + parts[i].length;
+    while (idx < trimmed.length && /\s/.test(trimmed[idx])) idx++;
+  }
+  return looksLikeHttpCommand(trimmed.substring(idx));
+}
+
+export function parseCrontabLine(input) {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  const parts = trimmed.split(/\s+/);
+  if (parts.length < 6) return null;
+
+  const cronExpr = parts.slice(0, 5).join(' ');
+  const schedule = crontabExpressionToSchedule(cronExpr);
+  if (!schedule) return null;
+
+  let idx = 0;
+  for (let i = 0; i < 5; i++) {
+    idx = trimmed.indexOf(parts[i], idx) + parts[i].length;
+    while (idx < trimmed.length && /\s/.test(trimmed[idx])) idx++;
+  }
+  const commandStr = trimmed.substring(idx);
+
+  const command = parseHttpCommand(commandStr);
+  if (!command || !command.url) return null;
+
+  return { schedule, command };
+}
+
 export function parseHttpCommand(input) {
   if (typeof input !== 'string') return null;
 

--- a/frontend/src/utils/CommandParser.test.js
+++ b/frontend/src/utils/CommandParser.test.js
@@ -1,4 +1,4 @@
-import { looksLikeHttpCommand, parseWget, parseHttpCommand } from './CommandParser';
+import { looksLikeHttpCommand, parseWget, parseHttpCommand, looksLikeCrontabLine, parseCrontabLine } from './CommandParser';
 import { RequestMethod } from './Constants';
 
 describe('looksLikeHttpCommand', () => {
@@ -168,5 +168,121 @@ describe('parseHttpCommand', () => {
     const r = parseHttpCommand('wget --method=PATCH https://example.com');
     expect(Object.prototype.hasOwnProperty.call(RequestMethod, r.method)).toBe(true);
     expect(RequestMethod[r.method]).toBe(RequestMethod.PATCH);
+  });
+});
+
+describe('looksLikeCrontabLine', () => {
+  it('detects a crontab line with curl', () => {
+    expect(looksLikeCrontabLine('*/5 * * * * curl https://example.com')).toBe(true);
+  });
+
+  it('detects a crontab line with wget', () => {
+    expect(looksLikeCrontabLine('0 3 * * * wget -q https://example.com/backup')).toBe(true);
+  });
+
+  it('detects complex schedule expressions', () => {
+    expect(looksLikeCrontabLine('0,30 1-5 */2 1,6,12 0-4 curl https://example.com')).toBe(true);
+  });
+
+  it('does not flag a plain curl/wget command (no schedule prefix)', () => {
+    expect(looksLikeCrontabLine('curl https://example.com')).toBe(false);
+    expect(looksLikeCrontabLine('wget https://example.com')).toBe(false);
+  });
+
+  it('does not flag a bare crontab expression without a command', () => {
+    expect(looksLikeCrontabLine('*/5 * * * *')).toBe(false);
+  });
+
+  it('does not flag a crontab line whose command is not curl/wget', () => {
+    expect(looksLikeCrontabLine('*/5 * * * * /usr/bin/python script.py')).toBe(false);
+  });
+
+  it('does not flag empty or non-string input', () => {
+    expect(looksLikeCrontabLine('')).toBe(false);
+    expect(looksLikeCrontabLine(null)).toBe(false);
+    expect(looksLikeCrontabLine(42)).toBe(false);
+  });
+});
+
+describe('parseCrontabLine', () => {
+  it('parses a simple crontab line with curl', () => {
+    const r = parseCrontabLine('*/5 * * * * curl https://example.com/api');
+    expect(r).not.toBeNull();
+    expect(r.schedule.minutes).toEqual([0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]);
+    expect(r.schedule.hours).toEqual([-1]);
+    expect(r.schedule.mdays).toEqual([-1]);
+    expect(r.schedule.months).toEqual([-1]);
+    expect(r.schedule.wdays).toEqual([-1]);
+    expect(r.command.url).toBe('https://example.com/api');
+  });
+
+  it('parses a daily-at-3am crontab line with wget', () => {
+    const r = parseCrontabLine('0 3 * * * wget -q -O /dev/null https://example.com/backup');
+    expect(r.schedule.minutes).toEqual([0]);
+    expect(r.schedule.hours).toEqual([3]);
+    expect(r.command.url).toBe('https://example.com/backup');
+  });
+
+  it('parses a complex schedule with curl flags', () => {
+    const r = parseCrontabLine("0,30 9-17 * * 1-5 curl -X POST -H 'Content-Type: application/json' -d '{\"ping\":true}' https://example.com/api");
+    expect(r.schedule.minutes).toEqual([0, 30]);
+    expect(r.schedule.hours).toEqual(expect.arrayContaining([9, 10, 11, 12, 13, 14, 15, 16, 17]));
+    expect(r.schedule.hours).toHaveLength(9);
+    expect(r.schedule.wdays).toEqual([1, 2, 3, 4, 5]);
+    expect(r.command.url).toBe('https://example.com/api');
+    expect(r.command.method).toBe('POST');
+    expect(r.command.body).toBe('{"ping":true}');
+  });
+
+  it('parses a monthly schedule', () => {
+    const r = parseCrontabLine('0 0 1 * * curl https://example.com/monthly');
+    expect(r.schedule.minutes).toEqual([0]);
+    expect(r.schedule.hours).toEqual([0]);
+    expect(r.schedule.mdays).toEqual([1]);
+    expect(r.command.url).toBe('https://example.com/monthly');
+  });
+
+  it('handles step expressions in all fields', () => {
+    const r = parseCrontabLine('*/10 */2 */5 */3 * curl https://example.com');
+    expect(r.schedule.minutes).toEqual([0, 10, 20, 30, 40, 50]);
+    expect(r.schedule.hours).toEqual([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]);
+  });
+
+  it('handles curl with path prefix', () => {
+    const r = parseCrontabLine('0 * * * * /usr/bin/curl https://example.com');
+    expect(r).not.toBeNull();
+    expect(r.command.url).toBe('https://example.com');
+  });
+
+  it('handles extra whitespace between fields', () => {
+    const r = parseCrontabLine('0  3   *  *  *   curl https://example.com');
+    expect(r.schedule.minutes).toEqual([0]);
+    expect(r.schedule.hours).toEqual([3]);
+    expect(r.command.url).toBe('https://example.com');
+  });
+
+  it('returns null for an invalid cron expression', () => {
+    expect(parseCrontabLine('99 * * * * curl https://example.com')).toBeNull();
+  });
+
+  it('returns null for a crontab line with a non-HTTP command', () => {
+    expect(parseCrontabLine('*/5 * * * * /bin/bash script.sh')).toBeNull();
+  });
+
+  it('returns null for a crontab line where curl has no URL', () => {
+    expect(parseCrontabLine('*/5 * * * * curl -X POST')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(parseCrontabLine(null)).toBeNull();
+    expect(parseCrontabLine(42)).toBeNull();
+  });
+
+  it('round-trips: schedule matches crontabExpressionToSchedule for the same expression', () => {
+    const { crontabExpressionToSchedule } = require('./CrontabExpression');
+    const cronExpr = '30 2 15 1,7 *';
+    const r = parseCrontabLine(cronExpr + ' curl https://example.com');
+    const direct = crontabExpressionToSchedule(cronExpr);
+    expect(r.schedule).toEqual(direct);
   });
 });


### PR DESCRIPTION
## Summary

Closes #12.

When a user pastes a full crontab line such as `*/5 * * * * curl https://example.com/api -X POST`, the frontend now detects the cron schedule prefix, extracts it, and populates **both** the execution schedule and the URL/method/headers/body/auth fields — so a single paste creates a fully configured job.

### What changed

- **`CommandParser.js`**: added `looksLikeCrontabLine()` and `parseCrontabLine()`. They split the input into the first 5 whitespace-separated tokens (validated as cron fields), parse them with the existing `crontabExpressionToSchedule()`, then dispatch the remainder to `parseHttpCommand()` for the curl/wget part.

- **`JobEditor.jsx`**: `detectCommandInUrl()` now checks for crontab lines before plain commands. When a crontab line is detected, the banner says *"This looks like a crontab line"* (distinct from the existing command banner). On import, the schedule is applied via a key-remount of `JobSchedule` (same pattern used for the URL field's `ValidatingTextField`).

- **`CurlImportDialog.jsx`**: the dialog now also accepts wget commands and crontab lines. It tries `parseCrontabLine()` → `parseHttpCommand()` → `parseCurl()`. When a crontab line is pasted, the schedule is passed back to `JobEditor` via the existing `onImport` callback (new `schedule` property). The help text, placeholder and error message were updated accordingly.

- **i18n (EN + DE)**: new `crontabImport.title/text` keys for the detection banner, `appliedParts.schedule` for the success snackbar, updated dialog help/error/label strings.

### Detection logic

The crontab-line detector is deliberately conservative:
1. The first 5 tokens must match `^(?:\*(?:\/\d+)?|\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*)$` (standard cron field syntax)
2. Those 5 tokens must form a valid schedule (via `crontabExpressionToSchedule`)
3. The remainder must be a recognized curl or wget command (via `looksLikeHttpCommand`)

This means `curl https://example.com` (no schedule prefix) still follows the existing command-import path, and non-HTTP crontab lines like `*/5 * * * * /usr/bin/python script.py` are ignored.

### Test coverage

19 new tests added to `CommandParser.test.js` (45 total in the file, 117 across the suite):
- `looksLikeCrontabLine`: detection, false-positive guards (plain commands, bare expressions, non-HTTP commands)
- `parseCrontabLine`: simple/daily/complex/monthly schedules, step expressions, path-prefixed curl, extra whitespace, invalid expressions, no-URL commands, round-trip equivalence with `crontabExpressionToSchedule`

### Notes

- The pre-existing `App.test.js` failure (recharts ESM transforms, unrelated to this change) is still present on master.
- End-to-end UI verification of the schedule population requires a running backend (auth-gated routes); the behavior is covered by the unit tests of the parser and the key-remount pattern already validated in PRs #421/#423.