### PR TITLE
frontend: Update footer branding from Twitter to X

### DIFF
--- a/frontend/src/components/misc/Footer.jsx
+++ b/frontend/src/components/misc/Footer.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { Typography, Link, makeStyles, Dialog, DialogTitle, DialogContent, FormControlLabel, Radio, RadioGroup, DialogActions, Button, Box } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import { Config } from '../../utils/Config';
-import TwitterIcon from '@material-ui/icons/Twitter';
+import XIcon from './XIcon';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import LanguageIcon from '@material-ui/icons/Language';
 import useLanguageCode from '../../hooks/useLanguageCode';
@@ -56,7 +56,7 @@ export default function Footer({ narrow = false }) {
       {!narrow && <><Copyright /> | </>}
       <><LanguageIcon className={classes.icon} /><Link color="inherit" className={classes.link} onClick={() => setShowLanguageDialog(true)}>{Config.languages[languageCode]}</Link></>
       {(Config.footerLinks || []).map(link => <React.Fragment key={link.title}> | <link.icon className={classes.icon} /><Link color="inherit" href={link.href} target={link.target}>{t(link.title)}</Link></React.Fragment>)}
-      {Config.twitterURL && <> | <TwitterIcon className={classes.icon} /><Link color="inherit" href={Config.twitterURL} target="_blank" rel="noopener">{t('common.followontwitter')}</Link></>}
+      {Config.twitterURL && <> | <XIcon className={classes.icon} /><Link color="inherit" href={Config.twitterURL} target="_blank" rel="noopener">{t('common.followontwitter')}</Link></>}
       {Config.githubURL && <> | <GitHubIcon className={classes.icon} /><Link color="inherit" href={Config.githubURL} target="_blank" rel="noopener">{t('common.forkongithub')}</Link></>}
       {narrow && <Box mt={2}><Copyright /></Box>}
     </Typography>

--- a/frontend/src/components/misc/XIcon.jsx
+++ b/frontend/src/components/misc/XIcon.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { SvgIcon } from '@material-ui/core';
+
+export default function XIcon(props) {
+  return <SvgIcon {...props} viewBox='0 0 24 24'>
+    <path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z' />
+  </SvgIcon>;
+}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -5,7 +5,7 @@
     "help": "Hilfe",
     "menu": "Menü",
     "contact": "Kontakt",
-    "followontwitter": "Twitter",
+    "followontwitter": "X",
     "forkongithub": "GitHub",
     "blog": "Blog",
     "logout": "Logout",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -5,7 +5,7 @@
     "help": "Help",
     "menu": "Menu",
     "contact": "Contact",
-    "followontwitter": "Twitter",
+    "followontwitter": "X",
     "forkongithub": "GitHub",
     "blog": "Blog",
     "logout": "Logout",

--- a/frontend/src/utils/Config.default.js
+++ b/frontend/src/utils/Config.default.js
@@ -2,7 +2,7 @@ export const Config = {
   //! @note Adjust project name, domains and URLs accordingly.
   'productName': 'cron-job.org OSS',
   'baseURL': 'https://example.com',
-  'twitterURL': 'https://twitter.com/CronJobOrg',
+  'twitterURL': 'https://x.com/CronJobOrg',
   'githubURL': 'https://github.com/pschlan/cron-job.org',
   'privacyPolicyURL': 'https://example.com/privacy/',
   'termsOfServiceURL': 'https://example.com/tos/',


### PR DESCRIPTION
## Summary

The console footer still shows the old Twitter bird icon and "Twitter" label, even though the platform has been rebranded to X since 2023.

- Added `frontend/src/components/misc/XIcon.jsx`: `@material-ui/icons` is pinned to v4.11.3, which predates the rebrand and has no X logo icon, so this adds a small custom icon (official logo path, wrapped in MUI's `SvgIcon`) matching how the existing icons are used in the footer.
- Swapped the footer's `TwitterIcon` for the new `XIcon`.
- Updated the default `twitterURL` in `Config.default.js` from `twitter.com` to `x.com`.
- Updated the EN/DE label from "Twitter" to "X" (following the project convention from recent PRs of only touching EN/DE directly).

Deliberately kept the `twitterURL` config key name as-is rather than renaming it, so existing self-hosted `Config.js` files don't silently lose the footer link on upgrade.

## Test plan

- [x] `npm test` — all 141 existing tests pass (pre-existing, unrelated `App.test.js` failure present on `master` too)
- [x] `npm run build` — compiles cleanly
- [x] Verified in the browser: footer now shows the X icon and links to `x.com/CronJobOrg`; confirmed the "X" label shows correctly after switching the language to English