### PR TITLE
api: Log when rate limiting is skipped due to Redis being unavailable

### DIFF
--- a/api/lib/RateLimiter.php
+++ b/api/lib/RateLimiter.php
@@ -36,19 +36,25 @@ class RateLimiter {
   public static function checkWithKey($key, $expire, $checkFunction) {
     $redis = RedisConnection::get();
     if ($redis === null) {
+      error_log('RateLimiter: Redis is not configured/connected, skipping rate limit check for key "' . $key . '"!');
       return true;
     }
 
-    $value = $redis->get($key);
-    if ($value !== false && !$checkFunction($value)) {
-      return false;
+    try {
+      $value = $redis->get($key);
+      if ($value !== false && !$checkFunction($value)) {
+        return false;
+      }
+
+      $res = $redis->multi()
+        ->incr($key)
+        ->expire($key, $expire)
+        ->exec();
+
+      return true;
+    } catch (RedisException $ex) {
+      error_log('RateLimiter: Redis is unreachable, skipping rate limit check for key "' . $key . '": ' . (string)$ex);
+      return true;
     }
-
-    $res = $redis->multi()
-      ->incr($key)
-      ->expire($key, $expire)
-      ->exec();
-
-    return true;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #446. Per the discussion there, this doesn't change the fail-open behavior (still prioritizes availability, as intended) — it just makes the degradation visible via `error_log()`, matching the logging convention already used in `APIDispatcher.php`/`RESTDispatcher.php`.

Two paths are covered in `RateLimiter::checkWithKey()`:

1. **Redis not configured/connected** (`RedisConnection::get()` returns `null`) — this was the case originally described in #446.
2. **Redis becomes unreachable mid-operation** — e.g. a successful connection at boot, followed by a restart or network blip while handling a request. I wrapped the actual Redis calls in a `try`/`catch (RedisException $ex)`. I want to flag this part explicitly: I couldn't verify against a live Redis instance whether phpredis throws `RedisException` on connection loss in your exact deployment configuration (this depends on the `redis.exceptions` ini setting, which isn't set anywhere in this repo, so it's whatever the extension's default is — `1`/enabled as of phpredis 5.x). If it does throw, this previously would have propagated all the way up to the top-level catch in `index.php` and returned a 500 for the whole request (not actually failing open) — this change makes it consistent with the intended "prioritize availability" behavior instead. If `RedisException` is never actually thrown in practice for your setup, this catch block is simply unreachable and harmless. Happy to drop this half if you'd rather keep the scope to exactly the reported case.

## Test plan

There's no PHPUnit/test suite for the PHP API in this repo, so I couldn't add or run automated tests. Verified with `php -l api/lib/RateLimiter.php` (no syntax errors) and by tracing both call sites (`APIDispatcher.php` via `RateLimiter::check()`, and `RESTDispatcher.php` which also calls `checkWithKey()` directly) to confirm the return contract (bool) is unchanged. Would appreciate a real test against your Redis setup before merging, especially for the `RedisException` path.