### PR TITLE
frontend: Move -G data into the query string on cURL import

### DIFF
--- a/frontend/src/utils/CurlParser.js
+++ b/frontend/src/utils/CurlParser.js
@@ -253,6 +253,11 @@ function appendBody(current, addition) {
   return current + '&' + addition;
 }
 
+function appendQuery(url, query) {
+  if (!query) return url;
+  return url + (url.includes('?') ? '&' : '?') + query;
+}
+
 export function parseCurl(input) {
   if (typeof input !== 'string') return null;
 
@@ -283,6 +288,7 @@ export function parseCurl(input) {
   };
   let explicitMethod = false;
   let formBody = false;
+  let forceGet = false;
 
   for (let i = start; i < tokens.length; i += 1) {
     const tok = tokens[i];
@@ -416,7 +422,9 @@ export function parseCurl(input) {
       }
       case '-G':
       case '--get': {
-        if (!explicitMethod) result.method = 'GET';
+        // The data is only known once all tokens have been seen, so the
+        // rewrite happens after the loop.
+        forceGet = true;
         break;
       }
       case '-I':
@@ -453,6 +461,15 @@ export function parseCurl(input) {
 
   // Strip wrapping quotes (in case the URL was double-quoted inside a single-quoted block, etc.)
   result.url = result.url.replace(/^['"]+/, '').replace(/['"]+$/, '');
+
+  // With -G, curl does not send the --data content as a request body but
+  // appends it to the URL's query string and performs a GET. An explicit -X
+  // still wins over the method, as it does in curl.
+  if (forceGet) {
+    result.url = appendQuery(result.url, result.body);
+    result.body = null;
+    if (!explicitMethod) result.method = 'GET';
+  }
 
   // If --data was used and no Content-Type was sent, curl defaults to
   // application/x-www-form-urlencoded. Mirror that so the job actually

--- a/frontend/src/utils/CurlParser.js
+++ b/frontend/src/utils/CurlParser.js
@@ -255,6 +255,7 @@ function appendBody(current, addition) {
 
 function appendQuery(url, query) {
   if (!query) return url;
+  if (/[?&]$/.test(url)) return url + query;
   return url + (url.includes('?') ? '&' : '?') + query;
 }
 

--- a/frontend/src/utils/CurlParser.js
+++ b/frontend/src/utils/CurlParser.js
@@ -468,6 +468,7 @@ export function parseCurl(input) {
   if (forceGet) {
     result.url = appendQuery(result.url, result.body);
     result.body = null;
+    formBody = false;
     if (!explicitMethod) result.method = 'GET';
   }
 

--- a/frontend/src/utils/CurlParser.test.js
+++ b/frontend/src/utils/CurlParser.test.js
@@ -191,6 +191,13 @@ describe('parseCurl', () => {
     expect(r.body).toBeNull();
   });
 
+  it('does not add a second separator when the -G URL ends with ? or &', () => {
+    expect(parseCurl("curl -G -d 'a=1' 'https://example.com/s?'").url)
+      .toBe('https://example.com/s?a=1');
+    expect(parseCurl("curl -G -d 'b=2' 'https://example.com/s?a=1&'").url)
+      .toBe('https://example.com/s?a=1&b=2');
+  });
+
   it('keeps an explicit method when -G is used', () => {
     const r = parseCurl("curl -X POST -G -d 'a=1' https://example.com");
     expect(r.method).toBe('POST');

--- a/frontend/src/utils/CurlParser.test.js
+++ b/frontend/src/utils/CurlParser.test.js
@@ -198,6 +198,11 @@ describe('parseCurl', () => {
     expect(r.body).toBeNull();
   });
 
+  it('does not add a form Content-Type when -G moved the data into the URL', () => {
+    const r = parseCurl("curl -G -d 'a=1' https://example.com");
+    expect(r.headers.find(h => h.key.toLowerCase() === 'content-type')).toBeUndefined();
+  });
+
   it('leaves the URL alone when -G is given without data', () => {
     const r = parseCurl('curl -G https://example.com/s');
     expect(r.url).toBe('https://example.com/s');

--- a/frontend/src/utils/CurlParser.test.js
+++ b/frontend/src/utils/CurlParser.test.js
@@ -178,6 +178,32 @@ describe('parseCurl', () => {
     expect(parseCurl("curl --data-binary @file https://example.com").body).toBe('@file');
   });
 
+  it('moves -d data into the query string when -G is used', () => {
+    const r = parseCurl("curl -G -d 'q=ada' -d 'lang=en' https://example.com/search");
+    expect(r.url).toBe('https://example.com/search?q=ada&lang=en');
+    expect(r.method).toBe('GET');
+    expect(r.body).toBeNull();
+  });
+
+  it('appends -G data to a URL which already has a query string', () => {
+    const r = parseCurl("curl --get --data-urlencode 'q=a b' 'https://example.com/s?page=2'");
+    expect(r.url).toBe('https://example.com/s?page=2&q=a%20b');
+    expect(r.body).toBeNull();
+  });
+
+  it('keeps an explicit method when -G is used', () => {
+    const r = parseCurl("curl -X POST -G -d 'a=1' https://example.com");
+    expect(r.method).toBe('POST');
+    expect(r.url).toBe('https://example.com?a=1');
+    expect(r.body).toBeNull();
+  });
+
+  it('leaves the URL alone when -G is given without data', () => {
+    const r = parseCurl('curl -G https://example.com/s');
+    expect(r.url).toBe('https://example.com/s');
+    expect(r.method).toBe('GET');
+  });
+
   it('handles --json by adding both Content-Type and Accept', () => {
     const r = parseCurl("curl --json '{\"a\":1}' https://example.com");
     expect(r.method).toBe('POST');


### PR DESCRIPTION
The cURL importer treats `-G` / `--get` as "use GET unless -X says otherwise" and leaves the `--data` content in the request body. curl does the opposite: it appends the data to the URL's query string and sends no body at all.

Pasting

    curl -G -d 'q=ada' -d 'lang=en' https://example.com/search

therefore creates a POST job with a `q=ada&lang=en` body and a `Content-Type: application/x-www-form-urlencoded` header, which does not reproduce the pasted command. It fails silently, so it is easy to miss until the job runs against the real endpoint.

With this change the same command imports as a GET of `https://example.com/search?q=ada&lang=en` with no body.

Details:

* The rewrite happens once all tokens have been read, so `-G` before or after the `-d` flags behaves the same.
* An explicit `-X` still wins over the method (`curl -X POST -G -d a=1` stays a POST with the data in the URL), as in curl.
* The implied form `Content-Type` is no longer added when there is no body left to describe.
* The data is appended with `?` or `&`, without doubling the separator when the URL already ends in one.

Six new cases in `CurlParser.test.js` cover this; the existing tests are untouched and still pass.